### PR TITLE
Add 'bin' folder to exclude files list

### DIFF
--- a/backend/examples/SuperBrewer3000/.theia/settings.json
+++ b/backend/examples/SuperBrewer3000/.theia/settings.json
@@ -1,8 +1,9 @@
 {
    "files.exclude": {
-      "**/.classpath": true,
-      "**/.project": true,
-      "**/.settings": true,
-      "**/.factorypath": true
-   }
+    "**/.classpath": true,
+    "**/.project": true,
+    "**/.settings": true,
+    "**/.factorypath": true,
+    "bin": true
+}
 }


### PR DESCRIPTION
By adding the 'bin' folder to the list of excluded files,
the bin folder is hidden in the navigator.