### PR TITLE
Use default browser instead of firefox beeing hardcoded

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -132,7 +132,7 @@ fi
 
 if [ "$runFrontend" == "true" ]; then
   workspace=$(pwd)
-  (sleep 5 && firefox 127.1:3000/#/${workspace:1}/backend/examples/SuperBrewer3000)&
+  (sleep 5 && x-www-browser http://127.1:3000/#/${workspace:1}/backend/examples/SuperBrewer3000)&
   cd web/browser-app
   yarn start --hostname 0.0.0.0
 fi


### PR DESCRIPTION
Instead of using 'firefox', 'x-www-browser' is used.
Thus the default browser is used instead.

Fix #203