### PR TITLE
Fixes #330: Update to GLSP release v0.8.x

### DIFF
--- a/backend/plugins/com.eclipsesource.coffee.modelserver/pom.xml
+++ b/backend/plugins/com.eclipsesource.coffee.modelserver/pom.xml
@@ -57,11 +57,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emfcloud.modelserver</groupId>
-			<artifactId>org.eclipse.emfcloud.modelserver.emf</artifactId>
-			<version>0.7.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.emfcloud.modelserver</groupId>
 			<artifactId>org.eclipse.emfcloud.modelserver.lib</artifactId>
 			<version>0.7.0-SNAPSHOT</version>
 		</dependency>

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/pom.xml
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/pom.xml
@@ -40,12 +40,12 @@
 		<dependency>
 			<groupId>org.eclipse.glsp</groupId>
 			<artifactId>org.eclipse.glsp.server</artifactId>
-			<version>0.8.0-rc-02</version>
+			<version>0.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.glsp</groupId>
 			<artifactId>org.eclipse.glsp.layout</artifactId>
-			<version>0.8.0-rc-02</version>
+			<version>0.8.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emfcloud.modelserver</groupId>

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/WorfklowDiagramNotationConfiguration.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/WorfklowDiagramNotationConfiguration.java
@@ -28,9 +28,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.emf.ecore.EClass;
-import org.eclipse.glsp.api.diagram.DiagramConfiguration;
-import org.eclipse.glsp.api.types.EdgeTypeHint;
-import org.eclipse.glsp.api.types.ShapeTypeHint;
+import org.eclipse.glsp.server.diagram.DiagramConfiguration;
+import org.eclipse.glsp.server.diagram.EdgeTypeHint;
+import org.eclipse.glsp.server.diagram.ShapeTypeHint;
 import org.eclipse.glsp.graph.DefaultTypes;
 import org.eclipse.glsp.graph.GraphPackage;
 

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/WorkflowCommandPaletteActionProvider.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/WorkflowCommandPaletteActionProvider.java
@@ -17,17 +17,17 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.api.operation.kind.CreateEdgeOperation;
-import org.eclipse.glsp.api.operation.kind.CreateNodeOperation;
-import org.eclipse.glsp.api.operation.kind.DeleteOperation;
-import org.eclipse.glsp.api.provider.CommandPaletteActionProvider;
-import org.eclipse.glsp.api.types.EditorContext;
-import org.eclipse.glsp.api.types.LabeledAction;
 import org.eclipse.glsp.graph.GModelElement;
 import org.eclipse.glsp.graph.GModelIndex;
 import org.eclipse.glsp.graph.GNode;
 import org.eclipse.glsp.graph.GPoint;
+import org.eclipse.glsp.server.features.commandpalette.CommandPaletteActionProvider;
+import org.eclipse.glsp.server.features.directediting.LabeledAction;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.operations.CreateEdgeOperation;
+import org.eclipse.glsp.server.operations.CreateNodeOperation;
+import org.eclipse.glsp.server.operations.DeleteOperation;
+import org.eclipse.glsp.server.types.EditorContext;
 
 import com.eclipsesource.workflow.glsp.server.util.ModelTypes;
 import com.eclipsesource.workflow.glsp.server.wfgraph.TaskNode;
@@ -37,7 +37,7 @@ import com.google.common.collect.Sets;
 public class WorkflowCommandPaletteActionProvider implements CommandPaletteActionProvider {
 
 	@Override
-	public List<LabeledAction> getActions(EditorContext editorContext, GraphicalModelState modelState) {
+	public List<LabeledAction> getActions(EditorContext editorContext, GModelState modelState) {
 		List<LabeledAction> actions = Lists.newArrayList();
 
 		GModelIndex index = modelState.getIndex();

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/WorkflowContextMenuItemProvider.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/WorkflowContextMenuItemProvider.java
@@ -17,11 +17,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.api.operation.kind.CreateNodeOperation;
-import org.eclipse.glsp.api.provider.ContextMenuItemProvider;
-import org.eclipse.glsp.api.types.MenuItem;
 import org.eclipse.glsp.graph.GPoint;
+import org.eclipse.glsp.server.features.contextmenu.ContextMenuItemProvider;
+import org.eclipse.glsp.server.features.contextmenu.MenuItem;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.operations.CreateNodeOperation;
 
 import com.google.common.collect.Lists;
 
@@ -29,7 +29,7 @@ public class WorkflowContextMenuItemProvider implements ContextMenuItemProvider 
 
 	@Override
 	public List<MenuItem> getItems(List<String> selectedElementIds, GPoint position, Map<String, String> args,
-			GraphicalModelState modelState) {
+			GModelState modelState) {
 		MenuItem newAutTask = new MenuItem("newAutoTask", "Automated Task",
 				Arrays.asList(new CreateNodeOperation(AUTOMATED_TASK, position)), true);
 		MenuItem newManTask = new MenuItem("newManualTask", "Manual Task",

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/WorkflowGLSPModule.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/WorkflowGLSPModule.java
@@ -14,22 +14,22 @@ import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
 import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
 import org.eclipse.emfcloud.modelserver.edit.DefaultCommandCodec;
-import org.eclipse.glsp.api.configuration.ServerConfiguration;
-import org.eclipse.glsp.api.diagram.DiagramConfiguration;
-import org.eclipse.glsp.api.factory.ModelFactory;
-import org.eclipse.glsp.api.handler.ActionHandler;
-import org.eclipse.glsp.api.handler.OperationHandler;
-import org.eclipse.glsp.api.jsonrpc.GLSPServer;
-import org.eclipse.glsp.api.layout.ILayoutEngine;
-import org.eclipse.glsp.api.model.ModelStateProvider;
-import org.eclipse.glsp.api.provider.CommandPaletteActionProvider;
-import org.eclipse.glsp.api.provider.ContextMenuItemProvider;
 import org.eclipse.glsp.graph.GraphExtension;
-import org.eclipse.glsp.server.actionhandler.OperationActionHandler;
-import org.eclipse.glsp.server.actionhandler.SaveModelActionHandler;
-import org.eclipse.glsp.server.actionhandler.UndoRedoActionHandler;
+import org.eclipse.glsp.server.actions.ActionHandler;
+import org.eclipse.glsp.server.actions.SaveModelActionHandler;
 import org.eclipse.glsp.server.di.DefaultGLSPModule;
-import org.eclipse.glsp.server.di.MultiBindConfig;
+import org.eclipse.glsp.server.diagram.DiagramConfiguration;
+import org.eclipse.glsp.server.features.commandpalette.CommandPaletteActionProvider;
+import org.eclipse.glsp.server.features.contextmenu.ContextMenuItemProvider;
+import org.eclipse.glsp.server.features.core.model.ModelFactory;
+import org.eclipse.glsp.server.features.undoredo.UndoRedoActionHandler;
+import org.eclipse.glsp.server.layout.ILayoutEngine;
+import org.eclipse.glsp.server.layout.ServerLayoutConfiguration;
+import org.eclipse.glsp.server.model.ModelStateProvider;
+import org.eclipse.glsp.server.operations.OperationActionHandler;
+import org.eclipse.glsp.server.operations.OperationHandler;
+import org.eclipse.glsp.server.protocol.GLSPServer;
+import org.eclipse.glsp.server.utils.MultiBinding;
 
 import com.eclipsesource.workflow.glsp.server.handler.WorkflowOperationActionHandler;
 import com.eclipsesource.workflow.glsp.server.handler.WorkflowSaveModelActionHandler;
@@ -53,10 +53,10 @@ public class WorkflowGLSPModule extends DefaultGLSPModule {
 	protected Class<? extends ModelFactory> bindModelFactory() {
 		return WorkflowModelFactory.class;
 	}
-
+	
 	@Override
-	protected Class<? extends ServerConfiguration> bindServerConfiguration() {
-		return WorkflowServerConfiguration.class;
+	protected Class<? extends ServerLayoutConfiguration> bindServerLayoutConfiguration() {
+		return WorkflowServerLayoutConfiguration.class;
 	}
 
 	@Override
@@ -65,12 +65,13 @@ public class WorkflowGLSPModule extends DefaultGLSPModule {
 	}
 
 	@Override
+	@SuppressWarnings("rawtypes")
 	protected Class<? extends GLSPServer> bindGLSPServer() {
 		return WorkflowGLSPServer.class;
 	}
 
 	@Override
-	protected void configureActionHandlers(MultiBindConfig<ActionHandler> bindings) {
+	protected void configureActionHandlers(MultiBinding<ActionHandler> bindings) {
 		super.configureActionHandlers(bindings);
 		bindings.rebind(OperationActionHandler.class, WorkflowOperationActionHandler.class);
 		bindings.rebind(SaveModelActionHandler.class, WorkflowSaveModelActionHandler.class);
@@ -79,7 +80,7 @@ public class WorkflowGLSPModule extends DefaultGLSPModule {
 	}
 
 	@Override
-	protected void configureOperationHandlers(MultiBindConfig<OperationHandler> bindings) {
+	protected void configureOperationHandlers(MultiBinding<OperationHandler> bindings) {
 		bindings.add(CreateAutomatedTaskHandler.class);
 		bindings.add(CreateManualTaskHandler.class);
 		bindings.add(CreateDecisionNodeHandler.class);
@@ -100,7 +101,7 @@ public class WorkflowGLSPModule extends DefaultGLSPModule {
 	}
 
 	@Override
-	protected void configureDiagramConfigurations(MultiBindConfig<DiagramConfiguration> bindings) {
+	protected void configureDiagramConfigurations(MultiBinding<DiagramConfiguration> bindings) {
 		bindings.add(WorfklowDiagramNotationConfiguration.class);
 	}
 

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/WorkflowGLSPServer.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/WorkflowGLSPServer.java
@@ -19,7 +19,6 @@ import org.eclipse.emfcloud.modelserver.client.Response;
 import org.eclipse.glsp.server.jsonrpc.DefaultGLSPServer;
 
 import com.eclipsesource.workflow.glsp.server.WorkflowGLSPServer.InitializeOptions;
-import com.eclipsesource.workflow.glsp.server.model.WorkflowModelState;
 import com.google.inject.Inject;
 
 public class WorkflowGLSPServer extends DefaultGLSPServer<InitializeOptions> {
@@ -37,29 +36,17 @@ public class WorkflowGLSPServer extends DefaultGLSPServer<InitializeOptions> {
 			Log.debug(String.format("[%s] Pinging modelserver at: '%s'", options.getTimestamp(),
 					options.getModelserverURL()));
 			try {
-				@SuppressWarnings("resource")
 				ModelServerClient client = new ModelServerClient(options.getModelserverURL());
 				boolean alive = client.ping().thenApply(Response<Boolean>::body).get();
 				if (alive) {
 					modelServerClientProvider.setModelServerClient(client);
 					return CompletableFuture.completedFuture(true);
 				}
-
 			} catch (Exception e) {
 				Log.error("Error during initialization of modelserver connection", e);
 			}
 		}
 		return CompletableFuture.completedFuture(false);
-	}
-
-	@Override
-	public void exit(String clientId) {
-		modelStateProvider.getModelState(clientId).ifPresent(ms -> {
-			if (ms instanceof WorkflowModelState) {
-				((WorkflowModelState) ms).getModelAccess().unsubscribe();
-			}
-		});
-		super.exit(clientId);
 	}
 
 	public class InitializeOptions {

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/WorkflowLayoutEngine.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/WorkflowLayoutEngine.java
@@ -10,14 +10,14 @@
  ******************************************************************************/
 package com.eclipsesource.workflow.glsp.server;
 
-import org.eclipse.glsp.api.model.GraphicalModelState;
 import org.eclipse.glsp.graph.GGraph;
 import org.eclipse.glsp.layout.ElkLayoutEngine;
 import org.eclipse.glsp.layout.GLSPLayoutConfigurator;
+import org.eclipse.glsp.server.model.GModelState;
 
 public class WorkflowLayoutEngine extends ElkLayoutEngine {
    @Override
-   public void layout(final GraphicalModelState modelState) {
+   public void layout(final GModelState modelState) {
       if (modelState.getRoot() instanceof GGraph) {
          GLSPLayoutConfigurator configurator = new GLSPLayoutConfigurator();
          configurator.configureByType("graph");

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/WorkflowServerLayoutConfiguration.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/WorkflowServerLayoutConfiguration.java
@@ -10,10 +10,10 @@
  ******************************************************************************/
 package com.eclipsesource.workflow.glsp.server;
 
-import org.eclipse.glsp.api.configuration.ServerConfiguration;
-import org.eclipse.glsp.api.layout.ServerLayoutKind;
+import org.eclipse.glsp.server.layout.ServerLayoutConfiguration;
+import org.eclipse.glsp.server.layout.ServerLayoutKind;
 
-public class WorkflowServerConfiguration implements ServerConfiguration{
+public class WorkflowServerLayoutConfiguration implements ServerLayoutConfiguration {
 
 	@Override
 	public ServerLayoutKind getLayoutKind() {

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/WorkflowOperationActionHandler.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/WorkflowOperationActionHandler.java
@@ -12,12 +12,12 @@ package com.eclipsesource.workflow.glsp.server.handler;
 
 import java.util.List;
 
-import org.eclipse.glsp.api.action.Action;
-import org.eclipse.glsp.api.handler.OperationHandler;
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.api.operation.Operation;
-import org.eclipse.glsp.api.registry.OperationHandlerRegistry;
-import org.eclipse.glsp.server.actionhandler.OperationActionHandler;
+import org.eclipse.glsp.server.actions.Action;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.operations.Operation;
+import org.eclipse.glsp.server.operations.OperationActionHandler;
+import org.eclipse.glsp.server.operations.OperationHandler;
+import org.eclipse.glsp.server.operations.OperationHandlerRegistry;
 
 import com.eclipsesource.workflow.glsp.server.handler.operation.ModelserverAwareOperationHandler;
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelServerAccess;
@@ -30,7 +30,7 @@ public class WorkflowOperationActionHandler extends OperationActionHandler {
 
 	@Override
 	protected List<Action> executeHandler(final Operation operation, final OperationHandler handler,
-			final GraphicalModelState modelState) {
+			final GModelState modelState) {
 		handler.execute(operation, modelState);
 		if (!(handler instanceof ModelserverAwareOperationHandler)) {
 			// if the handler is not model server aware, we simply update the whole model

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/WorkflowSaveModelActionHandler.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/WorkflowSaveModelActionHandler.java
@@ -13,12 +13,12 @@ package com.eclipsesource.workflow.glsp.server.handler;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import org.eclipse.glsp.api.action.Action;
-import org.eclipse.glsp.api.action.kind.SaveModelAction;
-import org.eclipse.glsp.api.action.kind.SetDirtyStateAction;
-import org.eclipse.glsp.api.jsonrpc.GLSPServerException;
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.server.actionhandler.BasicActionHandler;
+import org.eclipse.glsp.server.actions.Action;
+import org.eclipse.glsp.server.actions.BasicActionHandler;
+import org.eclipse.glsp.server.actions.SaveModelAction;
+import org.eclipse.glsp.server.actions.SetDirtyStateAction;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.protocol.GLSPServerException;
 
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelServerAccess;
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelState;
@@ -26,7 +26,7 @@ import com.eclipsesource.workflow.glsp.server.model.WorkflowModelState;
 public class WorkflowSaveModelActionHandler extends BasicActionHandler<SaveModelAction> {
 
 	@Override
-	protected List<Action> executeAction(SaveModelAction action, GraphicalModelState modelState) {
+	protected List<Action> executeAction(SaveModelAction action, GModelState modelState) {
 		try {
 			if (action != null) {
 				WorkflowModelServerAccess modelAccess = WorkflowModelState.getModelAccess(modelState);

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/AbstractCreateEdgeHandler.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/AbstractCreateEdgeHandler.java
@@ -19,8 +19,8 @@ import org.eclipse.emfcloud.modelserver.coffee.model.coffee.CoffeeFactory;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.CoffeePackage;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Flow;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Workflow;
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.api.operation.kind.CreateEdgeOperation;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.operations.CreateEdgeOperation;
 
 import com.eclipsesource.workflow.glsp.server.model.WorkflowFacade;
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelServerAccess;
@@ -38,7 +38,7 @@ public abstract class AbstractCreateEdgeHandler
 	}
 
 	@Override
-	public void executeOperation(CreateEdgeOperation operation, GraphicalModelState modelState,
+	public void executeOperation(CreateEdgeOperation operation, GModelState modelState,
 			WorkflowModelServerAccess modelAccess) throws Exception {
 		WorkflowFacade workflowFacade = modelAccess.getWorkflowFacade();
 		Workflow workflow = workflowFacade.getCurrentWorkflow();

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/AbstractCreateNodeHandler.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/AbstractCreateNodeHandler.java
@@ -21,8 +21,8 @@ import org.eclipse.emfcloud.modelserver.coffee.model.coffee.CoffeeFactory;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.CoffeePackage;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Node;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Workflow;
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.api.operation.kind.CreateNodeOperation;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.operations.CreateNodeOperation;
 
 import com.eclipsesource.workflow.glsp.server.model.ShapeUtil;
 import com.eclipsesource.workflow.glsp.server.model.WorkflowFacade;
@@ -41,7 +41,7 @@ public abstract class AbstractCreateNodeHandler
 	}
 
 	@Override
-	public void executeOperation(CreateNodeOperation operation, GraphicalModelState modelState,
+	public void executeOperation(CreateNodeOperation operation, GModelState modelState,
 			WorkflowModelServerAccess modelAccess) throws Exception {
 		WorkflowFacade workflowFacade = modelAccess.getWorkflowFacade();
 		Workflow workflow = workflowFacade.getCurrentWorkflow();
@@ -78,7 +78,7 @@ public abstract class AbstractCreateNodeHandler
 		workflow.getNodes().remove(node);
 	}
 
-	protected Node initializeNode(Node node, GraphicalModelState modelState) {
+	protected Node initializeNode(Node node, GModelState modelState) {
 		return node;
 	}
 }

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/AbstractCreateTaskHandler.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/AbstractCreateTaskHandler.java
@@ -13,7 +13,7 @@ package com.eclipsesource.workflow.glsp.server.handler.operation;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Node;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Task;
-import org.eclipse.glsp.api.model.GraphicalModelState;
+import org.eclipse.glsp.server.model.GModelState;
 
 import com.google.common.base.Preconditions;
 
@@ -24,7 +24,7 @@ public abstract class AbstractCreateTaskHandler extends AbstractCreateNodeHandle
 	}
 
 	@Override
-	protected Node initializeNode(Node node, GraphicalModelState modelState) {
+	protected Node initializeNode(Node node, GModelState modelState) {
 		Preconditions.checkArgument(node instanceof Task);
 		((Task) node).setName("NewTask");
 		return node;

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/ApplyLabelEditOperationHandler.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/ApplyLabelEditOperationHandler.java
@@ -18,18 +18,18 @@ import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.CoffeePackage;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Node;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Task;
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.api.operation.kind.ApplyLabelEditOperation;
 import org.eclipse.glsp.graph.GLabel;
 import org.eclipse.glsp.graph.GModelElement;
 import org.eclipse.glsp.graph.GNode;
+import org.eclipse.glsp.server.features.directediting.ApplyLabelEditOperation;
+import org.eclipse.glsp.server.model.GModelState;
 
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelServerAccess;
 
 public class ApplyLabelEditOperationHandler extends ModelServerAwareBasicOperationHandler<ApplyLabelEditOperation> {
 
 	@Override
-	public void executeOperation(ApplyLabelEditOperation operation, GraphicalModelState modelState,
+	public void executeOperation(ApplyLabelEditOperation operation, GModelState modelState,
 			WorkflowModelServerAccess modelAccess) throws Exception {
 		Optional<GModelElement> element = modelState.getIndex().get(operation.getLabelId());
 		if (!element.isPresent() && !(element.get() instanceof GLabel)) {

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/ChangeBoundsOperationHandler.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/ChangeBoundsOperationHandler.java
@@ -13,10 +13,10 @@ package com.eclipsesource.workflow.glsp.server.handler.operation;
 import java.util.Optional;
 
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Node;
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.api.operation.kind.ChangeBoundsOperation;
-import org.eclipse.glsp.api.types.ElementAndBounds;
-import org.eclipse.glsp.server.operationhandler.BasicOperationHandler;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.operations.BasicOperationHandler;
+import org.eclipse.glsp.server.operations.ChangeBoundsOperation;
+import org.eclipse.glsp.server.types.ElementAndBounds;
 
 import com.eclipsesource.workflow.glsp.server.model.ShapeUtil;
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelServerAccess;
@@ -27,13 +27,13 @@ import com.eclipsesource.workflow.glsp.server.wfnotation.Shape;
 public class ChangeBoundsOperationHandler extends BasicOperationHandler<ChangeBoundsOperation> {
 
 	@Override
-	public void executeOperation(ChangeBoundsOperation operation, GraphicalModelState modelState) {
+	public void executeOperation(ChangeBoundsOperation operation, GModelState modelState) {
 		for (ElementAndBounds element : operation.getNewBounds()) {
 			changeElementBounds(element, modelState);
 		}
 	}
 
-	private void changeElementBounds(ElementAndBounds element, GraphicalModelState modelState) {
+	private void changeElementBounds(ElementAndBounds element, GModelState modelState) {
 		WorkflowModelServerAccess modelAccess = WorkflowModelState.getModelAccess(modelState);
 		Node node = modelAccess.getNodeById(element.getElementId());
 		Optional<DiagramElement> diagramElement = modelAccess.getWorkflowFacade().findDiagramElement(node);

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/ChangeRoutingPointsOperationHandler.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/ChangeRoutingPointsOperationHandler.java
@@ -10,7 +10,7 @@
  ******************************************************************************/
 package com.eclipsesource.workflow.glsp.server.handler.operation;
 
-import static org.eclipse.glsp.api.jsonrpc.GLSPServerException.getOrThrow;
+import static org.eclipse.glsp.server.protocol.GLSPServerException.getOrThrow;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,11 +18,11 @@ import java.util.stream.Collectors;
 
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Flow;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Node;
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.api.operation.kind.ChangeRoutingPointsOperation;
-import org.eclipse.glsp.api.types.ElementAndRoutingPoints;
 import org.eclipse.glsp.graph.GEdge;
-import org.eclipse.glsp.server.operationhandler.BasicOperationHandler;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.operations.BasicOperationHandler;
+import org.eclipse.glsp.server.operations.ChangeRoutingPointsOperation;
+import org.eclipse.glsp.server.types.ElementAndRoutingPoints;
 
 import com.eclipsesource.workflow.glsp.server.model.ShapeUtil;
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelServerAccess;
@@ -33,11 +33,11 @@ import com.eclipsesource.workflow.glsp.server.wfnotation.Point;
 public class ChangeRoutingPointsOperationHandler extends BasicOperationHandler<ChangeRoutingPointsOperation> {
 
 	@Override
-	public void executeOperation(ChangeRoutingPointsOperation operation, GraphicalModelState modelState) {
+	public void executeOperation(ChangeRoutingPointsOperation operation, GModelState modelState) {
 		operation.getNewRoutingPoints().forEach(ear -> applyRoutingPointsChange(ear, modelState));
 	}
 
-	private void applyRoutingPointsChange(ElementAndRoutingPoints ear, GraphicalModelState modelState) {
+	private void applyRoutingPointsChange(ElementAndRoutingPoints ear, GModelState modelState) {
 		GEdge gEdge = getOrThrow(modelState.getIndex().findElementByClass(ear.getElementId(), GEdge.class),
 				"Invalid edge: edge ID " + ear.getElementId());
 		// reroute

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/DeleteOperationHandler.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/DeleteOperationHandler.java
@@ -18,12 +18,12 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Flow;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Node;
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.api.operation.kind.DeleteOperation;
 import org.eclipse.glsp.graph.GEdge;
 import org.eclipse.glsp.graph.GModelElement;
 import org.eclipse.glsp.graph.GNode;
-import org.eclipse.glsp.server.operationhandler.BasicOperationHandler;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.operations.BasicOperationHandler;
+import org.eclipse.glsp.server.operations.DeleteOperation;
 
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelServerAccess;
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelState;
@@ -35,13 +35,13 @@ public class DeleteOperationHandler extends BasicOperationHandler<DeleteOperatio
 	private Set<EObject> toDelete;
 
 	@Override
-	public void executeOperation(DeleteOperation operation, GraphicalModelState modelState) {
+	public void executeOperation(DeleteOperation operation, GModelState modelState) {
 		toDelete = new HashSet<>();
 		operation.getElementIds().forEach(id -> collectElementsToDelete(id, modelState));
 		toDelete.forEach(e -> EcoreUtil.delete(e, true));
 	}
 
-	protected void collectElementsToDelete(String id, GraphicalModelState modelState) {
+	protected void collectElementsToDelete(String id, GModelState modelState) {
 		Optional<GModelElement> maybeModelElement = modelState.getIndex().get(id);
 		if (maybeModelElement.isEmpty()) {
 			return;

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/ModelServerAwareBasicCreateOperationHandler.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/ModelServerAwareBasicCreateOperationHandler.java
@@ -10,10 +10,10 @@
  ******************************************************************************/
 package com.eclipsesource.workflow.glsp.server.handler.operation;
 
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.api.operation.CreateOperation;
-import org.eclipse.glsp.api.utils.GenericsUtil;
-import org.eclipse.glsp.server.operationhandler.BasicCreateOperationHandler;
+import org.eclipse.glsp.server.internal.util.GenericsUtil;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.operations.BasicCreateOperationHandler;
+import org.eclipse.glsp.server.operations.CreateOperation;
 
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelServerAccess;
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelState;
@@ -33,7 +33,7 @@ public abstract class ModelServerAwareBasicCreateOperationHandler<T extends Crea
 	}
 
 	@Override
-	public void executeOperation(final T operation, final GraphicalModelState modelState) {
+	public void executeOperation(final T operation, final GModelState modelState) {
 		if (handles(operation)) {
 			try {
 				WorkflowModelServerAccess modelAccess = WorkflowModelState.getModelAccess(modelState);

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/ModelServerAwareBasicOperationHandler.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/ModelServerAwareBasicOperationHandler.java
@@ -10,10 +10,10 @@
  ******************************************************************************/
 package com.eclipsesource.workflow.glsp.server.handler.operation;
 
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.api.operation.Operation;
-import org.eclipse.glsp.api.utils.GenericsUtil;
-import org.eclipse.glsp.server.operationhandler.BasicOperationHandler;
+import org.eclipse.glsp.server.internal.util.GenericsUtil;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.operations.BasicOperationHandler;
+import org.eclipse.glsp.server.operations.Operation;
 
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelServerAccess;
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelState;
@@ -29,7 +29,7 @@ public abstract class ModelServerAwareBasicOperationHandler<T extends Operation>
 	}
 
 	@Override
-	public void executeOperation(final T operation, final GraphicalModelState modelState) {
+	public void executeOperation(final T operation, final GModelState modelState) {
 		if (handles(operation)) {
 			try {
 				WorkflowModelServerAccess modelAccess = WorkflowModelState.getModelAccess(modelState);

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/ModelserverAwareOperationHandler.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/ModelserverAwareOperationHandler.java
@@ -10,14 +10,14 @@
  ******************************************************************************/
 package com.eclipsesource.workflow.glsp.server.handler.operation;
 
-import org.eclipse.glsp.api.handler.OperationHandler;
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.api.operation.Operation;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.operations.Operation;
+import org.eclipse.glsp.server.operations.OperationHandler;
 
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelServerAccess;
 
 public interface ModelserverAwareOperationHandler<T extends Operation> extends OperationHandler {
 
-	public void executeOperation(T operation, GraphicalModelState modelState, WorkflowModelServerAccess modelAccess)
+	public void executeOperation(T operation, GModelState modelState, WorkflowModelServerAccess modelAccess)
 			throws Exception;
 }

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/ReconnectFlowHandler.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/handler/operation/ReconnectFlowHandler.java
@@ -14,11 +14,11 @@ import java.util.Optional;
 
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Flow;
 import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Node;
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.api.operation.kind.ReconnectEdgeOperation;
 import org.eclipse.glsp.graph.GEdge;
 import org.eclipse.glsp.graph.GModelElement;
-import org.eclipse.glsp.server.operationhandler.BasicOperationHandler;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.operations.BasicOperationHandler;
+import org.eclipse.glsp.server.operations.ReconnectEdgeOperation;
 
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelServerAccess;
 import com.eclipsesource.workflow.glsp.server.model.WorkflowModelState;
@@ -26,10 +26,10 @@ import com.eclipsesource.workflow.glsp.server.model.WorkflowModelState;
 public class ReconnectFlowHandler extends BasicOperationHandler<ReconnectEdgeOperation> {
 
 	@Override
-	public void executeOperation(ReconnectEdgeOperation operation, GraphicalModelState modelState) {
+	public void executeOperation(ReconnectEdgeOperation operation, GModelState modelState) {
 		WorkflowModelServerAccess modelAccess = WorkflowModelState.getModelAccess(modelState);
 
-		Optional<GModelElement> maybeEdge = modelState.getIndex().get(operation.getConnectionElementId());
+		Optional<GModelElement> maybeEdge = modelState.getIndex().get(operation.getEdgeElementId());
 		if (maybeEdge.isEmpty() && !(maybeEdge.get() instanceof GEdge)) {
 			throw new IllegalArgumentException();
 		}

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/model/WorkflowModelServerAccess.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/model/WorkflowModelServerAccess.java
@@ -42,8 +42,8 @@ import org.eclipse.emfcloud.modelserver.coffee.model.coffee.Node;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.common.codecs.EncodingException;
 import org.eclipse.emfcloud.modelserver.edit.CommandCodec;
-import org.eclipse.glsp.api.jsonrpc.GLSPServerException;
 import org.eclipse.glsp.graph.GNode;
+import org.eclipse.glsp.server.protocol.GLSPServerException;
 
 import com.eclipsesource.workflow.glsp.server.wfnotation.WfnotationPackage;
 import com.google.common.base.Preconditions;

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/model/WorkflowModelState.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/model/WorkflowModelState.java
@@ -10,14 +10,14 @@
  ******************************************************************************/
 package com.eclipsesource.workflow.glsp.server.model;
 
-import org.eclipse.glsp.api.model.GraphicalModelState;
-import org.eclipse.glsp.server.model.ModelStateImpl;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.model.GModelStateImpl;
 
-public class WorkflowModelState extends ModelStateImpl {
+public class WorkflowModelState extends GModelStateImpl {
 
 	private WorkflowModelServerAccess modelAccess;
 
-	public static WorkflowModelServerAccess getModelAccess(GraphicalModelState state) {
+	public static WorkflowModelServerAccess getModelAccess(GModelState state) {
 		if (!(state instanceof WorkflowModelState)) {
 			throw new IllegalArgumentException("Argument must be a ModelServerAwareModelState");
 		}

--- a/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/model/WorkflowModelStateProvider.java
+++ b/backend/plugins/com.eclipsesource.workflow.glsp.server/src/main/java/com/eclipsesource/workflow/glsp/server/model/WorkflowModelStateProvider.java
@@ -10,15 +10,15 @@
  ******************************************************************************/
 package com.eclipsesource.workflow.glsp.server.model;
 
-import org.eclipse.glsp.api.model.GraphicalModelState;
 import org.eclipse.glsp.server.model.DefaultModelStateProvider;
+import org.eclipse.glsp.server.model.GModelState;
 
 import com.google.inject.Singleton;
 
 @Singleton
 public class WorkflowModelStateProvider extends DefaultModelStateProvider {
 	@Override
-	protected GraphicalModelState createModelState() {
+	protected GModelState createModelState() {
 		return new WorkflowModelState();
 	}
 }

--- a/web/coffee-workflow-glsp-editor/package.json
+++ b/web/coffee-workflow-glsp-editor/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@eclipse-glsp/client": "next",
-    "@eclipse-glsp-examples/workflow-sprotty": "next",
+    "@eclipse-glsp-examples/workflow-glsp": "next",
     "@eclipse-glsp/theia-integration": "next",
     "@eclipse-emfcloud/modelserver-theia": "next",
     "@theia/core": "latest",

--- a/web/coffee-workflow-glsp-editor/src/browser/diagram/workflow-diagram-configuration.ts
+++ b/web/coffee-workflow-glsp-editor/src/browser/diagram/workflow-diagram-configuration.ts
@@ -15,11 +15,11 @@
  ********************************************************************************/
 import 'sprotty-theia/css/theia-sprotty.css';
 
-import { createWorkflowDiagramContainer } from '@eclipse-glsp-examples/workflow-sprotty/lib';
+import { createWorkflowDiagramContainer } from '@eclipse-glsp-examples/workflow-glsp/lib';
 import { CommandPalette, TYPES } from '@eclipse-glsp/client/lib';
 import { GLSPTheiaDiagramServer, TheiaCommandPalette } from '@eclipse-glsp/theia-integration/lib/browser';
 import {
-    connectTheiaDiagramService,
+    connectTheiaContextMenuService,
     TheiaContextMenuServiceFactory
 } from '@eclipse-glsp/theia-integration/lib/browser/diagram/glsp-theia-context-menu-service';
 import { SelectionService } from '@theia/core';
@@ -37,13 +37,14 @@ export class WorkflowDiagramConfiguration implements DiagramConfiguration {
 
     createContainer(widgetId: string): Container {
         const container = createWorkflowDiagramContainer(widgetId);
+
         container.bind(TYPES.ModelSource).to(GLSPTheiaDiagramServer).inSingletonScope();
         container.bind(TheiaDiagramServer).toService(GLSPTheiaDiagramServer);
         // container.rebind(KeyTool).to(TheiaKeyTool).inSingletonScope()
         container.bind(TYPES.IActionHandlerInitializer).to(TheiaSprottySelectionForwarder);
         container.bind(SelectionService).toConstantValue(this.selectionService);
         container.rebind(CommandPalette).to(TheiaCommandPalette);
-        connectTheiaDiagramService(container, this.contextMenuServiceFactory);
+        connectTheiaContextMenuService(container, this.contextMenuServiceFactory);
 
         return container;
     }

--- a/web/coffee-workflow-glsp-editor/src/browser/diagram/workflow-diagram-manager.ts
+++ b/web/coffee-workflow-glsp-editor/src/browser/diagram/workflow-diagram-manager.ts
@@ -14,9 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 import {
+    DiagramWidgetOptions,
     GLSPDiagramManager,
     GLSPNotificationManager,
-    GLSPTheiaSprottyConnector
+    GLSPTheiaSprottyConnector,
+    GLSPWidgetOpenerOptions,
+    GLSPWidgetOptions
 } from '@eclipse-glsp/theia-integration/lib/browser';
 import { MessageService } from '@theia/core';
 import { WidgetManager, WidgetOpenerOptions } from '@theia/core/lib/browser';
@@ -56,7 +59,7 @@ export class WorkflowDiagramManager extends GLSPDiagramManager {
         });
     }
 
-    protected createWidgetOptions(uri: URI, options?: WidgetOpenerOptions): Record<string, any> {
+    protected createWidgetOptions(uri: URI, options?: GLSPWidgetOpenerOptions): DiagramWidgetOptions & GLSPWidgetOptions {
         const widgetOptions = super.createWidgetOptions(uri.withoutQuery(), options);
         const queryOptions = this.createQueryOptions(uri);
         const serverOptions = this.createServerOptions(options);

--- a/web/coffee-workflow-glsp-editor/src/browser/frontend-module.ts
+++ b/web/coffee-workflow-glsp-editor/src/browser/frontend-module.ts
@@ -13,15 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { GLSPClientContribution } from '@eclipse-glsp/theia-integration/lib/browser';
-import {
-    FrontendApplicationContribution,
-    LabelProviderContribution,
-    OpenHandler,
-    WidgetFactory
-} from '@theia/core/lib/browser';
+import { GLSPClientContribution, registerDiagramManager } from '@eclipse-glsp/theia-integration/lib/browser';
+import { LabelProviderContribution } from '@theia/core/lib/browser';
 import { ContainerModule, interfaces } from 'inversify';
-import { DiagramConfiguration, DiagramManager, DiagramManagerProvider } from 'sprotty-theia/lib';
+import { DiagramConfiguration } from 'sprotty-theia/lib';
 
 import { WorkflowDiagramConfiguration } from './diagram/workflow-diagram-configuration';
 import { WorkflowDiagramLabelProviderContribution } from './diagram/workflow-diagram-label-provider-contribution';
@@ -32,20 +27,8 @@ import { WorkflowGLSPClientContribution } from './language/workflow-glsp-client-
 export default new ContainerModule((bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
     bind(WorkflowGLSPClientContribution).toSelf().inSingletonScope();
     bind(GLSPClientContribution).toService(WorkflowGLSPClientContribution);
-
-    bind(WorkflowGLSPDiagramClient).toSelf().inSingletonScope();
-
     bind(DiagramConfiguration).to(WorkflowDiagramConfiguration).inSingletonScope();
-    bind(WorkflowDiagramManager).toSelf().inSingletonScope();
-    bind(FrontendApplicationContribution).toService(WorkflowDiagramManager);
-    bind(OpenHandler).toService(WorkflowDiagramManager);
-    bind(WidgetFactory).toService(WorkflowDiagramManager);
-    bind(DiagramManagerProvider).toProvider<DiagramManager>(context =>
-        () =>
-            new Promise<DiagramManager>(resolve => {
-                const diagramManager = context.container.get<WorkflowDiagramManager>(WorkflowDiagramManager);
-                resolve(diagramManager);
-            }));
+    bind(WorkflowGLSPDiagramClient).toSelf().inSingletonScope();
+    registerDiagramManager(bind, WorkflowDiagramManager);
     bind(LabelProviderContribution).to(WorkflowDiagramLabelProviderContribution);
-
 });

--- a/web/package.json
+++ b/web/package.json
@@ -53,9 +53,9 @@
     "**/@theia/workspace": "1.2.0",
     "**/sprotty": "0.9.0-next.7028f2a",
     "**/sprotty-theia": "0.9.0-next.72ba049",
-    "**/@eclipse-glsp/client": "0.8.0-rc-02",
-    "**/@eclipse-glsp/theia-integration": "0.8.0-rc-02",
-    "**/@eclipse-glsp-examples/workflow-sprotty": "0.8.0-rc-02",
+    "**/@eclipse-glsp/client": "0.8.1",
+    "**/@eclipse-glsp/theia-integration": "0.8.0",
+    "**/@eclipse-glsp-examples/workflow-glsp": "0.8.1",
     "**/@eclipse-emfcloud/modelserver-theia": "0.8.0-next.5bf1df0",
     "**/typescript": "^3.9.3"
   }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -827,39 +827,40 @@
     redux "^4.0.4"
     uuid "^3.3.2"
 
-"@eclipse-glsp-examples/workflow-sprotty@0.8.0-rc-02", "@eclipse-glsp-examples/workflow-sprotty@next":
-  version "0.8.0-rc-02"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-sprotty/-/workflow-sprotty-0.8.0-rc-02.tgz#6bea4678a1d3d0d061b465b9928ffcff564afed1"
-  integrity sha512-MSy+psimJe/+CDqk6+9lBa1Od2MwDdhhyiVIlOy1E7zAat7FZSIhJYVvjF8T6Hdaosn6i1iALko3iUPO7xZd/A==
+"@eclipse-glsp-examples/workflow-glsp@0.8.1", "@eclipse-glsp-examples/workflow-glsp@next":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp-examples/workflow-glsp/-/workflow-glsp-0.8.1.tgz#8fdaf2e8462de1c33aed325421f5a4955f3c2407"
+  integrity sha512-b5MHDn6q0GfUdAy30ai+0f/eKwVyyKJsOCNWC8wbyVYo08Ug3MDKdlBf04QfZyWtnAlck3sbKxnutr0yE9jBpQ==
   dependencies:
-    "@eclipse-glsp/client" "0.8.0-rc-02"
+    "@eclipse-glsp/client" "0.8.1"
     balloon-css "^0.5.0"
 
-"@eclipse-glsp/client@0.8.0-rc-02", "@eclipse-glsp/client@next":
-  version "0.8.0-rc-02"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.8.0-rc-02.tgz#3a5777671e5aacbe04ef75af7755a809ca26bd45"
-  integrity sha512-YJrBfxSZKnR94MsPdqd1ZcbcdBVaq5vsu0WLk9xrrFIktKMAheIFImSy7qDwhnl95y53z5QCPoe+U3SXEciTLw==
+"@eclipse-glsp/client@0.8.1", "@eclipse-glsp/client@next":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-0.8.1.tgz#9b40aa0d68a35963fe5d570f28761c2ea2d6afde"
+  integrity sha512-4O3E02Po7tFAz+SUe2E87GIckQrmUhC8MuXaUs/k0fNb8gW9vZ8pHswWpNbaghzN3SEV5v4wJY+tcTu1FL6agg==
   dependencies:
+    "@eclipse-glsp/protocol" "0.8.0"
     autocompleter "5.1.0"
-    sprotty "0.9.0-next.7028f2a"
-    uuid "7.0.3"
-    vscode-ws-jsonrpc "^0.0.2-1"
+    sprotty "0.9.0"
 
-"@eclipse-glsp/theia-integration@0.8.0-rc-02", "@eclipse-glsp/theia-integration@next":
-  version "0.8.0-rc-02"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/theia-integration/-/theia-integration-0.8.0-rc-02.tgz#d6ff574034d67252b1e5d6f6003f8fbe6aab10e0"
-  integrity sha512-BJnMLhhAMOqk+FDICWWbKHEwr5vuI2QLZxGlek6ov0goNhkJjQvmSSM3xCHJejvLE2io79T7qZ//+NOhgN/HCA==
+"@eclipse-glsp/protocol@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-0.8.0.tgz#28e60a277af5364c8e9071752b9dba08b6f047c1"
+  integrity sha512-nWYMTGtBCD2JQlPZN9b03BcZ4YPIMPCDmm+vpr3nyuPkBVbzf28uwIoVypL3NVJU9P1saMfBP2gzmJ0r5FcZCg==
   dependencies:
-    "@eclipse-glsp/client" "0.8.0-rc-02"
-    "@theia/core" "1.0.0"
-    "@theia/editor" "1.0.0"
-    "@theia/filesystem" "1.0.0"
-    "@theia/languages" "1.0.0"
-    "@theia/messages" "1.0.0"
-    "@theia/monaco" "1.0.0"
-    "@theia/process" "1.0.0"
-    "@theia/workspace" "1.0.0"
-    sprotty-theia "0.9.0-next.72ba049"
+    uuid "7.0.3"
+    vscode-ws-jsonrpc "0.2.0"
+
+"@eclipse-glsp/theia-integration@0.8.0", "@eclipse-glsp/theia-integration@next":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/theia-integration/-/theia-integration-0.8.0.tgz#501cd4b62fd4cc4a8ff54402fc84343f33b3a6ed"
+  integrity sha512-fKR1ZF7AIMA1pqoSSWPyr55bb5KuzZSPfmKmeQIqyT9SEhXjZ2dAup6BXd8ELREhWY9Oe/w7XIvk0B8MNBvohg==
+  dependencies:
+    "@eclipse-glsp/client" "0.8.1"
+    "@eclipse-glsp/protocol" "0.8.0"
+    "@theia/messages" "^1.0.0"
+    sprotty-theia "0.9.0"
 
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
@@ -2178,7 +2179,7 @@
     "@theia/navigator" "^1.2.0"
     "@theia/workspace" "^1.2.0"
 
-"@theia/messages@1.0.0", "@theia/messages@1.2.0", "@theia/messages@^1.2.0", "@theia/messages@latest":
+"@theia/messages@1.2.0", "@theia/messages@^1.0.0", "@theia/messages@^1.2.0", "@theia/messages@latest":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@theia/messages/-/messages-1.2.0.tgz#acb554825dc2803de9164876f7e308643e4715f7"
   integrity sha512-NS25mbUVr9XqbZlbGoEaPzXEfkq0+3MFGlM/VH9r7dPie/5DtboGupNTjL4+69bsrLYqzOIV2RwxHD8EWmJbPg==
@@ -2371,7 +2372,7 @@
     "@theia/workspace" "^1.2.0"
     jsonc-parser "^2.0.2"
 
-"@theia/process@1.0.0", "@theia/process@1.2.0", "@theia/process@^1.2.0", "@theia/process@latest":
+"@theia/process@1.2.0", "@theia/process@^1.2.0", "@theia/process@latest":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@theia/process/-/process-1.2.0.tgz#e3a0f527d68ee2a38d6ff1683b2fb1616747ab7a"
   integrity sha512-LPrpF1hSG/XlwP2BOgD1O5jJiSKN5BW+sHuquWfv1ntyi+e2T2ZFwVmCMxPEVHAkLLAihlyDQtyhbxpSA4j0fA==
@@ -2467,7 +2468,7 @@
   dependencies:
     "@theia/core" "^1.2.0"
 
-"@theia/workspace@1.0.0", "@theia/workspace@1.2.0", "@theia/workspace@^1.0.0", "@theia/workspace@^1.2.0", "@theia/workspace@latest":
+"@theia/workspace@1.2.0", "@theia/workspace@^1.0.0", "@theia/workspace@^1.2.0", "@theia/workspace@latest":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@theia/workspace/-/workspace-1.2.0.tgz#0cf5332c2c1cc76bae3510c2f132aa50959b3125"
   integrity sha512-UxcXC7Ji0jh7Nr2ipbz0Q2x+ZoC7byLAUxSbodpFFaM7tpEEfmqZwOc7IXbRwVX7w7R6UUN+XWHsqhRCHXtvSg==
@@ -12931,7 +12932,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sprotty-theia@0.9.0-next.72ba049:
+sprotty-theia@0.9.0, sprotty-theia@0.9.0-next.72ba049:
   version "0.9.0-next.72ba049"
   resolved "https://registry.yarnpkg.com/sprotty-theia/-/sprotty-theia-0.9.0-next.72ba049.tgz#bc75767a7bd8927fc934d476236f6a9e03e99042"
   integrity sha512-Ipr8MYz+zoL/q4y45RoOjWznVASeO318+4b1HqQ0w25D6k46kSZWwjXVy+ShaQ2oTWwO0AWYyFjYzq8Kyik/bA==
@@ -12943,7 +12944,7 @@ sprotty-theia@0.9.0-next.72ba049:
     "@theia/monaco" "1.0.0"
     sprotty next
 
-sprotty@0.9.0-next.7028f2a, sprotty@next:
+sprotty@0.9.0, sprotty@0.9.0-next.7028f2a, sprotty@next:
   version "0.9.0-next.7028f2a"
   resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.9.0-next.7028f2a.tgz#48bae07b119f561b225159d66c43ada8174fb6f3"
   integrity sha512-XiI/8WXqjJM8KXu68wujwJRC8V2hqusgyTHu2XdAANLngbpWPRYhFCqvmtMiH7lsFLSHSdv1JYp5KvUaI3YoWA==
@@ -14179,11 +14180,6 @@ vscode-jsonrpc@4.0.0:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
   integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
 
-vscode-jsonrpc@^3.6.0:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-3.6.2.tgz#3b5eef691159a15556ecc500e9a8a0dd143470c8"
-  integrity sha512-T24Jb5V48e4VgYliUXMnZ379ItbrXgOimweKaJshD84z+8q7ZOZjJan0MeDe+Ugb+uqERDVV8SBmemaGMSMugA==
-
 vscode-jsonrpc@^4.1.0-next:
   version "4.1.0-next.3"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.1.0-next.3.tgz#05fe742959a2726020d4d0bfbc3d3c97873c7fde"
@@ -14256,14 +14252,7 @@ vscode-ws-jsonrpc@0.1.0:
   dependencies:
     vscode-jsonrpc "^4.1.0-next"
 
-vscode-ws-jsonrpc@^0.0.2-1:
-  version "0.0.2-2"
-  resolved "https://registry.yarnpkg.com/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-0.0.2-2.tgz#3d977ea40a2f47148ea8cfcbf077196ecd7fe3a2"
-  integrity sha512-hViHObJHtxD0KX8tvP6QL8fJGfH9mmDrEkdfLKj6Mf1uaxypoMBnjcZDCU3N4l7VriQiNRbohe/FlMrC3/0r7Q==
-  dependencies:
-    vscode-jsonrpc "^3.6.0"
-
-vscode-ws-jsonrpc@^0.2.0:
+vscode-ws-jsonrpc@0.2.0, vscode-ws-jsonrpc@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-0.2.0.tgz#5e9c26e10da54a1a235da7d59e74508bbcb8edd9"
   integrity sha512-NE9HNRgPjCaPyTJvIudcpyIWPImxwRDtuTX16yks7SAiZgSXigxAiZOvSvVBGmD1G/OMfrFo6BblOtjVR9DdVA==


### PR DESCRIPTION
- Update backend to GLSP release v0.8.0
-- Adapt to moved functionality in GLSP -> import fixes
-- Adapt to renamed classes and interfaces
--- GraphicalModelState -> GModelState
--- MultiBindConfig -> MultiBinding
--- ServerConfiguration -> ServerLayoutConfiguration
-- Move modelserver unsubscribe from server into GLSP session listener

- Update frontend to GLSP release v0.8.0 and 0.8.1

Signed-off-by: Martin Fleck <mfleck@eclipsesource.com>