### PR TITLE
Fix back-end copy on MacOS #312

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -69,7 +69,7 @@ if [ "$copyBackend" == "true" ]; then
 	echo "Running on Linux"
   elif [[ "$OSTYPE" == "darwin"* ]]; then
         # Mac OSX
-	productPath='macosx\cocoa'
+	productPath='macosx/cocoa'
 	echo "Running on Mac"
   elif [[ "$OSTYPE" == "cygwin" ]]; then
         # POSIX compatibility layer and Linux environment emulation for Windows


### PR DESCRIPTION
- Mac filesystem uses forward slashes

Signed-off-by: Christian W. Damus <give.a.damus@gmail.com>