### PR TITLE
Fix breaking master build

### DIFF
--- a/backend/plugins/com.eclipsesource.workflow.generator.java/build.properties
+++ b/backend/plugins/com.eclipsesource.workflow.generator.java/build.properties
@@ -1,5 +1,5 @@
 source.. = src/,\
-           target/xtend-gen/main/
+           xtend-gen/
 bin.includes = META-INF/,\
                .,\
                src/

--- a/backend/releng/com.eclipsesource.coffee.target/com.eclipsesource.coffee.target.target
+++ b/backend/releng/com.eclipsesource.coffee.target/com.eclipsesource.coffee.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Coffee 2020-09" sequenceNumber="1613061352">
+<target name="Coffee 2020-09" sequenceNumber="1614333774">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="com.google.gson" version="2.7.0.v20170129-0911"/>
@@ -37,7 +37,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202102101729/"/>
+      <repository location="https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202102161029/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.emfjson.jackson" version="0.0.0"/>

--- a/backend/releng/com.eclipsesource.coffee.target/com.eclipsesource.coffee.target.tpd
+++ b/backend/releng/com.eclipsesource.coffee.target/com.eclipsesource.coffee.target.tpd
@@ -42,7 +42,7 @@ location "http://download.eclipse.org/eclipse/updates/4.17/" eclipse-4.17 {
 location "http://download.eclipse.org/lsp4j/updates/releases/0.9.0" {
 	org.eclipse.lsp4j.sdk.feature.group lazy
 }
-location "https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202102101729/" {
+location "https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202102161029/" {
 	org.eclipse.emfcloud.modelserver.feature.feature.group lazy
 }
 location "http://ghillairet.github.io/p2" {


### PR DESCRIPTION
- Update updatesite for modelserver in target definition to point to an existing version.
(Due to a previous bug in our CI pipeline older snapshot versions have been removed from the modelserver p2 update site)