### PR TITLE
Make run script fail when a subtask fails

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 echo "$(date +"[%T.%3N]") Evaluate Options... "
 buildBackend='false'


### PR DESCRIPTION
Small fix that cancels the `run.sh` script if a subtask, like building the backend, fails.

Signed-off-by: Simon Graband <sgraband@eclipsesource.com>