### PR TITLE
Fix #356: Recalculate breadcrumb width

### DIFF
--- a/web/coffee-workflow-analyzer/wf-analyzer-web-app/analyze.css
+++ b/web/coffee-workflow-analyzer/wf-analyzer-web-app/analyze.css
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2019-2020 EclipseSource and others.
+ * Copyright (c) 2019-2021 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -72,7 +72,8 @@ body {
 }
 
 #legend {
-  padding: 10px 0 0 3px;
+  /* Sufficient top padding in case the breadcrumb is very long, to fit under it. */
+  padding: 50px 0 0 3px;
 }
 
 #sequence text, #legend text {

--- a/web/coffee-workflow-analyzer/wf-analyzer-web-app/index.html
+++ b/web/coffee-workflow-analyzer/wf-analyzer-web-app/index.html
@@ -243,15 +243,18 @@ function updateBreadcrumbs(nodeArray, percentageString) {
   g.exit().remove();
 
   // Now move and update the percentage at the end.
+  var trailLength = (nodeArray.length + 0.5) * (b.w + b.s);
   d3.select("#trail").select("#endlabel")
-      .attr("x", (nodeArray.length + 0.5) * (b.w + b.s))
+      .attr("x", trailLength)
       .attr("y", b.h / 2)
       .attr("dy", "0.35em")
       .attr("text-anchor", "middle")
       .text(percentageString);
 
-  // Make the breadcrumb trail visible, if it's hidden.
+  // Make the breadcrumb trail visible, if it's hidden. And wide enough to see it all
+  var endLabelWidth = d3.select("#trail").select("#endlabel").node().getComputedTextLength();
   d3.select("#trail")
+      .attr("width", trailLength + endLabelWidth + 10)
       .style("visibility", "");
 
 }


### PR DESCRIPTION
The PR #354 adds a new element to the example SuperBrewer3000 model, which results in a truncated breadcrumb. This is an expedient fix to make that look better.

- when updating the breadcrumb contents, recalculate its total width, too
- apply that width to the trail element to avoid truncation
- because the breadcrumb can now extend farther to the right, add top padding to the legend so that it will not occlude the breadcrumb
 
_A better solution might wrap the breadcrumb, but that should be a new feature, not in scope of this fix._
