### PR TITLE
Reenable the workflow analyzer

### DIFF
--- a/web/browser-app/package.json
+++ b/web/browser-app/package.json
@@ -40,7 +40,8 @@
     "coffee-java-extension": "0.7.0",
     "coffee-server": "0.7.0",
     "coffee-welcome-page": "0.7.0",
-    "coffee-workflow-glsp-editor": "0.7.0"
+    "coffee-workflow-glsp-editor": "0.7.0",
+    "coffee-workflow-analyzer": "0.7.0"
   },
   "devDependencies": {
     "@theia/cli": "^1.0.0"

--- a/web/coffee-server/src/node/workflow-lsp-launcher.ts
+++ b/web/coffee-server/src/node/workflow-lsp-launcher.ts
@@ -51,7 +51,9 @@ export class WorkflowLSPServerLauncher implements BackendApplicationContribution
         });
     }
 
-    protected spawnProcessAsync(command: string, args?: string[], options?: cp.SpawnOptions): Promise<RawProcess> {
+    protected async spawnProcessAsync(command: string, args?: string[], options?: cp.SpawnOptions): Promise<RawProcess> {
+        // delay start as we need the model server to be started
+        await new Promise(r => setTimeout(r, 10000));
         const rawProcess = this.processFactory({ command, args, options });
         rawProcess.errorStream.on('data', this.logError.bind(this));
         rawProcess.outputStream.on('data', this.logInfo.bind(this));


### PR DESCRIPTION
- add extension to browser-app/package.json
- add own express handler as it worked before vhosts
- delay lsp startup to make sure that the modelserver started