### PR TITLE
use correct tycho version for surefire

### DIFF
--- a/backend/releng/org.eclipse.emfcloud.coffee.parent/pom.xml
+++ b/backend/releng/org.eclipse.emfcloud.coffee.parent/pom.xml
@@ -235,7 +235,7 @@
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-surefire-plugin</artifactId>
-					<version>${tychoVersion}</version>
+					<version>${tycho-version}</version>
 					<configuration>
 						<!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
 						<argLine>${tycho.testArgLine} ${platformSystemProperties} ${systemProperties} ${moduleProperties}</argLine>


### PR DESCRIPTION
Hi,

i'm currently using the coffee-editor as a blueprint for a custom application and for that one i wanted to adapt tycho to the latest version. Did not work out as there was a typo in the <version> tag value for surefire. 

Greetings, 
Alex