### PR TITLE
Fix VSCode LSP Exension

### DIFF
--- a/web/coffee-workflow-analyzer-editor/tsconfig.json
+++ b/web/coffee-workflow-analyzer-editor/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../configs/base.tsconfig",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib",
+    "outDir": "out",
     "baseUrl": "."
   },
   "include": [


### PR DESCRIPTION
The wrong out dir was used, thus the vscode extension could not find the js file to load.

Fix #443