### PR TITLE
Fix validation after reload

### DIFF
--- a/backend/plugins/org.eclipse.emfcloud.coffee.modelserver/META-INF/MANIFEST.MF
+++ b/backend/plugins/org.eclipse.emfcloud.coffee.modelserver/META-INF/MANIFEST.MF
@@ -29,6 +29,7 @@ Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.emf.ecore.xmi;bundle-version="2.16.0",
  com.fasterxml.jackson.core.jackson-core;bundle-version="2.12.1",
  com.fasterxml.jackson.core.jackson-databind;bundle-version="2.12.1",
+ com.fasterxml.jackson.core.jackson-annotations;bundle-version="2.12.1",
  org.eclipse.emfcloud.emfjson-jackson;bundle-version="1.3.1"
 Export-Package: org.eclipse.emfcloud.coffee.modelserver,
  org.eclipse.emfcloud.coffee.modelserver.commands.compound,

--- a/backend/plugins/org.eclipse.emfcloud.coffee.modelserver/src/org/eclipse/emfcloud/coffee/modelserver/CoffeeModelServerModule.java
+++ b/backend/plugins/org.eclipse.emfcloud.coffee.modelserver/src/org/eclipse/emfcloud/coffee/modelserver/CoffeeModelServerModule.java
@@ -27,6 +27,7 @@ import org.eclipse.emfcloud.modelserver.common.utils.MapBinding;
 import org.eclipse.emfcloud.modelserver.common.utils.MultiBinding;
 import org.eclipse.emfcloud.modelserver.edit.CommandContribution;
 import org.eclipse.emfcloud.modelserver.emf.common.ModelResourceManager;
+import org.eclipse.emfcloud.modelserver.emf.common.ModelValidator;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.glsp.notation.integration.EMSNotationModelServerModule;
 
@@ -67,6 +68,11 @@ public class CoffeeModelServerModule extends EMSNotationModelServerModule {
       binding.put(RemoveFlowCommandContribution.TYPE, RemoveFlowCommandContribution.class);
       binding.put(SetFlowSourceCommandContribution.TYPE, SetFlowSourceCommandContribution.class);
       binding.put(SetFlowTargetCommandContribution.TYPE, SetFlowTargetCommandContribution.class);
+   }
+
+   @Override
+   protected Class<? extends ModelValidator> bindModelValidator() {
+      return CoffeeModelValidator.class;
    }
 
 }

--- a/backend/plugins/org.eclipse.emfcloud.coffee.modelserver/src/org/eclipse/emfcloud/coffee/modelserver/CoffeeModelValidator.java
+++ b/backend/plugins/org.eclipse.emfcloud.coffee.modelserver/src/org/eclipse/emfcloud/coffee/modelserver/CoffeeModelValidator.java
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (c) 2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.coffee.modelserver;
+
+import java.util.Optional;
+
+import org.eclipse.emf.common.util.BasicDiagnostic;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.Diagnostician;
+import org.eclipse.emfcloud.jackson.module.EMFModule;
+import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelValidator;
+import org.eclipse.emfcloud.modelserver.emf.common.ModelRepository;
+import org.eclipse.emfcloud.modelserver.emf.common.ValidationMapperModule;
+import org.eclipse.emfcloud.modelserver.emf.configuration.FacetConfig;
+import org.eclipse.emfcloud.modelserver.jsonschema.Json;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+public class CoffeeModelValidator extends DefaultModelValidator {
+   private static final Diagnostician DIAGNOSTICIAN = Diagnostician.INSTANCE;
+
+   @Inject
+   public CoffeeModelValidator(final ModelRepository modelRepository, final FacetConfig facetConfig,
+      final Provider<ObjectMapper> mapperProvider) {
+      super(modelRepository, facetConfig, mapperProvider);
+   }
+
+   @Override
+   public JsonNode validate(final String modeluri) {
+      Optional<EObject> model = this.modelRepository.getModel(modeluri);
+      Optional<Resource> res = this.modelRepository.loadResource(modeluri);
+      if (model.isEmpty() || res.isEmpty()) {
+         return Json.text("Model not found!");
+      }
+      ObjectMapper mapper = EMFModule.setupDefaultMapper();
+      mapper.registerModule(new ValidationMapperModule(res.get()));
+      mapper.setVisibility(PropertyAccessor.FIELD, Visibility.PROTECTED_AND_PUBLIC);
+      BasicDiagnostic diagnostics = DIAGNOSTICIAN.createDefaultDiagnostic(model.get());
+      DIAGNOSTICIAN.validate(model.get(), diagnostics, DIAGNOSTICIAN.createDefaultContext());
+      return mapper.valueToTree(diagnostics);
+   }
+}


### PR DESCRIPTION
Previously the validation would not return correct ids after a reload.
To fix this the validator needed to be updated.
A fix for the modelserver was opened, this is a workaround for now.
This can removed again, once we updated to the modelserver version
containing the fix.

Modelserver change for reference: https://github.com/eclipse-emfcloud/emfcloud-modelserver/pull/244

Fixes #449.