### PR TITLE
Update docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y git libxkbfile-dev libsecret-1-dev bash libsecret-1-0  maven openjdk-11-jdk
 
 # Theia build dependencies
-RUN  export DEBIAN_FRONTEND=noninteractive \
-	&& apt-get -y install --no-install-recommends \
+RUN  apt-get -y install --no-install-recommends \
 	software-properties-common \
 	libxkbfile-dev \
 	libsecret-1-dev \
@@ -26,21 +25,22 @@ RUN yarn install &&\
 	yarn copy:servers &
 
 FROM node:16-bullseye-slim as production-stage
+ENV DEBIAN_FRONTEND noninteractive
 
 
 # Theia dependencies/Java
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-	&& apt-get -y install --no-install-recommends \
+RUN apt-get update &&\
+	apt-get -y install --no-install-recommends \
 	software-properties-common \
 	libxkbfile-dev \
 	libsecret-1-dev openjdk-11-jdk \
-	build-essential libssl-dev  wget gnupg git mvn
+	build-essential libssl-dev  wget gnupg git maven
 
 # C/C++ dependencies
 RUN add-apt-repository 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main'
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-	&& apt-get -y install  clangd-14 &&\
+RUN apt-get update  &&\
+	apt-get -y install  clangd-14 &&\
 	apt-get purge -y && \
 	apt-get clean
 

--- a/client/browser-app/package.json
+++ b/client/browser-app/package.json
@@ -65,7 +65,7 @@
     "prepare": "yarn run download:plugins",
     "development": "theia build --mode development",
     "production": "theia build --mode production",
-    "start": "export WF_CONFIG_LSP=localhost:5017 && theia start --port=3000 --root-dir=../workspace/examples/SuperBrewer3000 --plugins=local-dir:./plugins",
+    "start": "export WF_CONFIG_LSP=localhost:5017 && theia start --port=3000 --root-dir=../workspace/SuperBrewer3000 --plugins=local-dir:./plugins",
     "start:debug": "export WF_CONFIG_LSP=localhost:5017 && theia start --port=3000 --WF_ANALYZER=5083 --root-dir=../workspace/SuperBrewer3000 --plugins=local-dir:./plugins  --loglevel=debug --debug",
     "watch": "theia build --watch --mode development",
     "download:plugins": "theia download:plugins"

--- a/k8s.dockerfile
+++ b/k8s.dockerfile
@@ -3,8 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y git libxkbfile-dev libsecret-1-dev bash libsecret-1-0  maven openjdk-11-jdk
 
 # Theia dependencies
-RUN  export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends \
+RUN apt-get -y install --no-install-recommends \
     software-properties-common \
     libxkbfile-dev \
     libsecret-1-dev \
@@ -32,10 +31,11 @@ RUN yarn install &&\
     yarn cache clean
 
 FROM node:16-bullseye-slim as production-stage
+ENV DEBIAN_FRONTEND noninteractive
 
 
 # Theia dependencies/Java
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+RUN apt-get update \
     && apt-get -y install --no-install-recommends \
     software-properties-common \
     libxkbfile-dev \
@@ -45,8 +45,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # C/C++ dependencies
 RUN add-apt-repository 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main'
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install  clangd-14 &&\
+RUN apt-get update &&\
+    apt-get -y install  clangd-14 &&\
     apt-get purge -y && \
     apt-get clean
 

--- a/k8s.dockerfile
+++ b/k8s.dockerfile
@@ -34,30 +34,6 @@ COPY ./client ./client
 
 WORKDIR /coffee-editor/client
 
-# Copy backend jars
-## ModelServer
-COPY --from=backend /coffee-editor/backend/plugins/org.eclipse.emfcloud.coffee.modelserver/target/org.eclipse.emfcloud.coffee.modelserver-0.1.0-SNAPSHOT-standalone.jar \
-    /coffee-editor/client/coffee-servers/servers/org.eclipse.emfcloud.coffee.modelserver-0.1.0-SNAPSHOT-standalone.jar
-## ModelServer Log4JConfig
-COPY --from=backend /coffee-editor/backend/plugins/org.eclipse.emfcloud.coffee.modelserver/log4j2-embedded.xml \
-    /coffee-editor/client/coffee-servers/servers/model-server-log4j2-embedded.xml
-## GLSP Server
-COPY --from=backend /coffee-editor/backend/plugins/org.eclipse.emfcloud.coffee.workflow.glsp.server/target/org.eclipse.emfcloud.coffee.workflow.glsp.server-0.1.0-SNAPSHOT-glsp.jar \
-    /coffee-editor/client/coffee-servers/servers/org.eclipse.emfcloud.coffee.workflow.glsp.server-0.1.0-SNAPSHOT-glsp.jar
-## Workflow LSP
-COPY --from=backend /coffee-editor/backend/releng/org.eclipse.emfcloud.coffee.product/target/products/org.eclipse.emfcloud.coffee.product.workflow.dsl/linux/gtk/x86_64 \
-    /coffee-editor/client/coffee-servers/servers/wf-ls
-## Workflow Analyzer
-COPY --from=backend /coffee-editor/backend/releng/org.eclipse.emfcloud.coffee.product/target/products/org.eclipse.emfcloud.coffee.product.workflow.analyzer/linux/gtk/x86_64 \
-    /coffee-editor/client/coffee-servers/servers/wf-analyzer
-## Java Codegenerator
-COPY --from=backend /coffee-editor/backend/releng/org.eclipse.emfcloud.coffee.product/target/products/org.eclipse.emfcloud.coffee.product.codegen/linux/gtk/x86_64 \
-    /coffee-editor/client/coffee-servers/servers/java-codegen
-## CPP Codegenerator
-COPY --from=backend /coffee-editor/backend/releng/org.eclipse.emfcloud.coffee.product/target/products/org.eclipse.emfcloud.coffee.product.codegen.cpp/linux/gtk/x86_64 \
-    /coffee-editor/client/coffee-servers/servers/cpp-codegen
-
-
 RUN yarn install &&\
     yarn production &&\
     yarn autoclean --init && \
@@ -97,6 +73,32 @@ RUN chmod -R 750 /var/run/
 RUN useradd -ms /bin/bash theia
 WORKDIR /coffee-editor
 COPY --chown=theia:theia  --from=frontend /coffee-editor/client ./client
+
+# Copy backend jars
+## ModelServer
+COPY --from=backend /coffee-editor/backend/plugins/org.eclipse.emfcloud.coffee.modelserver/target/org.eclipse.emfcloud.coffee.modelserver-0.1.0-SNAPSHOT-standalone.jar \
+    /coffee-editor/client/coffee-servers/servers/org.eclipse.emfcloud.coffee.modelserver-0.1.0-SNAPSHOT-standalone.jar
+## ModelServer Log4JConfig
+COPY --from=backend /coffee-editor/backend/plugins/org.eclipse.emfcloud.coffee.modelserver/log4j2-embedded.xml \
+    /coffee-editor/client/coffee-servers/servers/model-server-log4j2-embedded.xml
+## GLSP Server
+COPY --from=backend /coffee-editor/backend/plugins/org.eclipse.emfcloud.coffee.workflow.glsp.server/target/org.eclipse.emfcloud.coffee.workflow.glsp.server-0.1.0-SNAPSHOT-glsp.jar \
+    /coffee-editor/client/coffee-servers/servers/org.eclipse.emfcloud.coffee.workflow.glsp.server-0.1.0-SNAPSHOT-glsp.jar
+## Workflow LSP
+COPY --from=backend /coffee-editor/backend/releng/org.eclipse.emfcloud.coffee.product/target/products/org.eclipse.emfcloud.coffee.product.workflow.dsl/linux/gtk/x86_64 \
+    /coffee-editor/client/coffee-servers/servers/wf-ls
+## Workflow Analyzer
+COPY --from=backend /coffee-editor/backend/releng/org.eclipse.emfcloud.coffee.product/target/products/org.eclipse.emfcloud.coffee.product.workflow.analyzer/linux/gtk/x86_64 \
+    /coffee-editor/client/coffee-servers/servers/wf-analyzer
+## Java Codegenerator
+COPY --from=backend /coffee-editor/backend/releng/org.eclipse.emfcloud.coffee.product/target/products/org.eclipse.emfcloud.coffee.product.codegen/linux/gtk/x86_64 \
+    /coffee-editor/client/coffee-servers/servers/java-codegen
+## CPP Codegenerator
+COPY --from=backend /coffee-editor/backend/releng/org.eclipse.emfcloud.coffee.product/target/products/org.eclipse.emfcloud.coffee.product.codegen.cpp/linux/gtk/x86_64 \
+    /coffee-editor/client/coffee-servers/servers/cpp-codegen
+## Model
+COPY --from=backend /coffee-editor/backend/plugins/org.eclipse.emfcloud.coffee.model/target/org.eclipse.emfcloud.coffee.model-0.1.0-SNAPSHOT.jar \
+    /coffee-editor/backend/plugins/org.eclipse.emfcloud.coffee.model/target/org.eclipse.emfcloud.coffee.model-0.1.0-SNAPSHOT.jar
 
 WORKDIR /coffee-editor
 


### PR DESCRIPTION
- Update DockerFile to be based on debian bullseye slim instead of ubuntu-18.04. This is now the full blown dev image that contains all sources .
- Introduce a special k8s.DockerFile that is optimized for k8s deployment. It doesn't contain the backend sources, the client is built with the production flag and unnecessary files are cleaned afterwards.


Also: Fix the browser-app yarn start script which was pointing to a non-existing example path