### PR TITLE
#193 Add Community Health files to EMF.cloud repositories

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,46 +1,94 @@
 # Community Code of Conduct
 
-**Version 1.2  
-August 19, 2020**
+**Version 2.0  
+January 1, 2023**
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as community members, contributors, committers, and project leaders pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+In the interest of fostering an open and welcoming environment, we as community members, contributors, Committers[^1], and Project Leads (collectively "Contributors") pledge to make participation in our projects and our community a harassment-free and inclusive experience for everyone.
+
+This Community Code of Conduct ("Code") outlines our behavior expectations as members of our community in all Eclipse Foundation activities, both offline and online. It is not intended to govern scenarios or behaviors outside of the scope of Eclipse Foundation activities. Nor is it intended to replace or supersede the protections offered to all our community members under the law. Please follow both the spirit and letter of this Code and encourage other Contributors to follow these principles into our work. Failure to read or acknowledge this Code does not excuse a Contributor from compliance with the Code.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment include:
+Examples of behavior that contribute to creating a positive and professional environment include:
 
-*   Using welcoming and inclusive language
-*   Being respectful of differing viewpoints and experiences
-*   Gracefully accepting constructive criticism
-*   Focusing on what is best for the community
-*   Showing empathy towards other community members
+- Using welcoming and inclusive language;
+- Actively encouraging all voices;
+- Helping others bring their perspectives and listening actively. If you find yourself dominating a discussion, it is especially important to encourage other voices to join in;
+- Being respectful of differing viewpoints and experiences;
+- Gracefully accepting constructive criticism;
+- Focusing on what is best for the community;
+- Showing empathy towards other community members;
+- Being direct but professional; and
+- Leading by example by holding yourself and others accountable
 
-Examples of unacceptable behavior by participants include:
+Examples of unacceptable behavior by Contributors include:
 
-*   The use of sexualized language or imagery and unwelcome sexual attention or advances
-*   Trolling, insulting/derogatory comments, and personal or political attacks
-*   Public or private harassment
-*   Publishing others' private information, such as a physical or electronic address, without explicit permission
-*   Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery;
+- Unwelcome sexual attention or advances;
+- Trolling, insulting/derogatory comments, and personal or political attacks;
+- Public or private harassment, repeated harassment;
+- Publishing others' private information, such as a physical or electronic address, without explicit permission;
+- Violent threats or language directed against another person;
+- Sexist, racist, or otherwise discriminatory jokes and language;
+- Posting sexually explicit or violent material;
+- Sharing private content, such as emails sent privately or non-publicly, or unlogged forums such as IRC channel history;
+- Personal insults, especially those using racist or sexist terms;
+- Excessive or unnecessary profanity;
+- Advocating for, or encouraging, any of the above behavior; and
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Our Responsibilities
 
-With the support of the Eclipse Foundation staff (the “Staff”), project committers and leaders are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
-
-Project committers and leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+With the support of the Eclipse Foundation employees, consultants, officers, and directors (collectively, the "Staff"), Committers, and Project Leads, the Eclipse Foundation Conduct Committee (the "Conduct Committee") is responsible for clarifying the standards of acceptable behavior. The Conduct Committee takes appropriate and fair corrective action in response to any instances of unacceptable behavior.
 
 ## Scope
 
-This Code of Conduct applies within all project spaces, and it also applies when an individual is representing the Eclipse Foundation project or its community in public spaces. Examples of representing a project or community include posting via an official social media account, or acting as a project representative at an online or offline event. Representation of a project may be further defined and clarified by project committers, leaders, or the EMO.
+This Code applies within all Project, Working Group, and Interest Group spaces and communication channels of the Eclipse Foundation (collectively, "Eclipse spaces"), within any Eclipse-organized event or meeting, and in public spaces when an individual is representing an Eclipse Foundation Project, Working Group, Interest Group, or their communities. Examples of representing a Project or community include posting via an official social media account, personal accounts, or acting as an appointed representative at an online or offline event. Representation of Projects, Working Groups, and Interest Groups may be further defined and clarified by Committers, Project Leads, or the Staff.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Staff at codeofconduct@eclipse.org. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The Staff is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Conduct Committee via conduct@eclipse-foundation.org. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Without the explicit consent of the reporter, the Conduct Committee is obligated to maintain confidentiality with regard to the reporter of an incident. The Conduct Committee is further obligated to ensure that the respondent is provided with sufficient information about the complaint to reply. If such details cannot be provided while maintaining confidentiality, the Conduct Committee will take the respondent‘s inability to provide a defense into account in its deliberations and decisions. Further details of enforcement guidelines may be posted separately.
 
-Project committers or leaders who do not follow the Code of Conduct in good faith may face temporary or permanent repercussions as determined by the Staff.
+Staff, Committers and Project Leads have the right to report, remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code, or to block temporarily or permanently any Contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful. Any such actions will be reported to the Conduct Committee for transparency and record keeping.
 
-## Attribution
+Any Staff (including officers and directors of the Eclipse Foundation), Committers, Project Leads, or Conduct Committee members who are the subject of a complaint to the Conduct Committee will be recused from the process of resolving any such complaint.
 
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org) , version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct/)
+## Responsibility
+
+The responsibility for administering this Code rests with the Conduct Committee, with oversight by the Executive Director and the Board of Directors. For additional information on the Conduct Committee and its process, please write to <conduct@eclipse-foundation.org>.
+
+## Investigation of Potential Code Violations
+
+All conflict is not bad as a healthy debate may sometimes be necessary to push us to do our best. It is, however, unacceptable to be disrespectful or offensive, or violate this Code. If you see someone engaging in objectionable behavior violating this Code, we encourage you to address the behavior directly with those involved. If for some reason, you are unable to resolve the matter or feel uncomfortable doing so, or if the behavior is threatening or harassing, please report it following the procedure laid out below.
+
+Reports should be directed to <conduct@eclipse-foundation.org>. It is the Conduct Committee’s role to receive and address reported violations of this Code and to ensure a fair and speedy resolution.
+
+The Eclipse Foundation takes all reports of potential Code violations seriously and is committed to confidentiality and a full investigation of all allegations. The identity of the reporter will be omitted from the details of the report supplied to the accused. Contributors who are being investigated for a potential Code violation will have an opportunity to be heard prior to any final determination. Those found to have violated the Code can seek reconsideration of the violation and disciplinary action decisions. Every effort will be made to have all matters disposed of within 60 days of the receipt of the complaint.
+
+## Actions
+
+Contributors who do not follow this Code in good faith may face temporary or permanent repercussions as determined by the Conduct Committee.
+
+This Code does not address all conduct. It works in conjunction with our [Communication Channel Guidelines](https://www.eclipse.org/org/documents/communication-channel-guidelines/), [Social Media Guidelines](https://www.eclipse.org/org/documents/social_media_guidelines.php), [Bylaws](https://www.eclipse.org/org/documents/eclipse-foundation-be-bylaws-en.pdf), and [Internal Rules](https://www.eclipse.org/org/documents/ef-be-internal-rules.pdf) which set out additional protections for, and obligations of, all contributors. The Foundation has additional policies that provide further guidance on other matters.
+
+It’s impossible to spell out every possible scenario that might be deemed a violation of this Code. Instead, we rely on one another’s good judgment to uphold a high standard of integrity within all Eclipse Spaces. Sometimes, identifying the right thing to do isn’t an easy call. In such a scenario, raise the issue as early as possible.
+
+## No Retaliation
+
+The Eclipse community relies upon and values the help of Contributors who identify potential problems that may need to be addressed within an Eclipse Space. Any retaliation against a Contributor who raises an issue honestly is a violation of this Code. That a Contributor has raised a concern honestly or participated in an investigation, cannot be the basis for any adverse action, including threats, harassment, or discrimination. If you work with someone who has raised a concern or provided information in an investigation, you should continue to treat the person with courtesy and respect. If you believe someone has retaliated against you, report the matter as described by this Code. Honest reporting does not mean that you have to be right when you raise a concern; you just have to believe that the information you are providing is accurate.
+
+False reporting, especially when intended to retaliate or exclude, is itself a violation of this Code and will not be accepted or tolerated.
+
+Everyone is encouraged to ask questions about this Code. Your feedback is welcome, and you will get a response within three business days. Write to <conduct@eclipse-foundation.org>.
+
+## Amendments
+
+The Eclipse Foundation Board of Directors may amend this Code from time to time and may vary the procedures it sets out where appropriate in a particular case.
+
+### Attribution
+
+This Code was inspired by the [Contributor Covenant](https://www.contributor-covenant.org/), version 1.4, available [here](https://www.contributor-covenant.org/version/1/4/code-of-conduct/).
+
+[^1]: Capitalized terms used herein without definition shall have the meanings assigned to them in the Bylaws.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,43 +1,71 @@
-# Contributing to Eclipse EMF.cloud: Coffee Editor
+# Contributing to Eclipse EMF.cloud Coffee Editor IDE
 
-Thank you for your interest in the Coffee Editor project!
-The following is a set of guidelines for contributing to the Coffee Editor.
+Thank you for your interest in the EMF.cloud Coffee Editor IDE project!
+We welcome your contributions! Before you dive in, please find the following set of guidelines for contributing to EMF.cloud.
 
 ## Code of Conduct
 
-This project is governed by the [Eclipse Community Code of Conduct](CODE_OF_CONDUCT.md).
+This project is governed by the [Eclipse Community Code of Conduct](https://github.com/eclipse/.github/blob/master/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code.
+
+## Terms of Use
+
+This repository is subject to the [Terms of Use of the Eclipse Foundation](http://www.eclipse.org/legal/termsofuse.php).
 
 ## Communication
 
 The following communication channels are available:
 
-* [GitHub issues](https://github.com/eclipse-emfcloud/coffee-editor/issues) - for bug reports, feature requests, etc.
 * [GitHub Discussions](https://github.com/eclipse-emfcloud/emfcloud/discussions) - for questions
+* [GitHub issues](https://github.com/eclipse-emfcloud/coffee-editor/issues) - for project wide bug reports, feature requests, etc.
 * [Developer mailing list](https://accounts.eclipse.org/mailing-list/emfcloud-dev) - for organizational issues (e.g. elections of new committers)
 
 In case you have a question, please look into the [GitHub Discussions](https://github.com/eclipse-emfcloud/emfcloud/discussions) first.
-If you don't find any answer there, feel free to start a new discussion or create a new [issue](https://github.com/eclipse-emfcloud/coffee-editor/issues) to get help.
+If you don't find any answer there, feel free to start a new discussion or create a new issue in the respective repository to get help.
+
+## Eclipse Development Process
+
+This Eclipse Foundation open project is governed by the Eclipse Foundation
+Development Process and operates under the terms of the Eclipse IP Policy.
+
+* [Eclipse Foundation Development Process](https://eclipse.org/projects/dev_process)
+* [Eclipse Intellectual Property Policy](https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf)
 
 ## How to Contribute
 
-In order to contribute, please first open an issue in this project.
+In order to contribute, please first open an issue in the respective repository or in this repository if it is an project wide concern.
 This issue should describe the bug you intend to fix or the feature you would like to add.
 Once you have your code ready for review, please open a pull request in the respective repository.
 A [committer of the EMF.cloud project](https://projects.eclipse.org/projects/ecd.emfcloud/who) will then review your contribution and help to get it merged.
 
-Please note that before your pull request can be accepted, you must electronically sign the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php).
-For more information, see the [Eclipse Foundation Project Handbook](https://www.eclipse.org/projects/handbook/#resources-commit).
+### Eclipse Contributor Agreement
+
+In order to be able to contribute to Eclipse Foundation projects you must
+electronically sign the [Eclipse Contributor Agreement (ECA)](http://www.eclipse.org/legal/ECA.php).
+
+The ECA provides the Eclipse Foundation with a permanent record that you agree
+that each of your contributions will comply with the commitments documented in
+the Developer Certificate of Origin (DCO). Having an ECA on file associated with
+the email address matching the "Author" field of your contribution's Git commits
+fulfills the DCO's requirement that you sign-off on your contributions.
+
+For more information, please see the [Eclipse Committer Handbook](https://www.eclipse.org/projects/handbook/#resources-commit).
+
+### Signing the Eclipse Contributor Agreement
+
+You must digitally sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php). You can do this as follows:
+
+* If you haven't done so already, [register an Eclipse account](https://accounts.eclipse.org/user/register). **Important**: Use the same email address that you will use on Git commits as the author address.
+* Open the [ECA form](https://accounts.eclipse.org/user/eca) and complete it. See the [ECA FAQ](https://www.eclipse.org/legal/ecafaq.php) for more info.
 
 ### Branch names and commit messages
 
-If you are an [elected committer of the EMF.cloud project](https://projects.eclipse.org/projects/ecd.emfcloud/who) please create a branch in the repository directly.
+If you are an [elected committer of the EMF.cloud project](https://projects.eclipse.org/projects/ecd.emfcloud/who) please create a branch in the respective repository.
 Otherwise please fork and create a branch in your fork for the pull request.
 
-The branch name should be in the form `issues/{issue_number}`, e.g. `issues/16`. So please create an issue before creating a pull request.
+The branch name should be in the form `issues/{issue_number}`, e.g. `issues/115`. So please create an issue before creating a pull request.
 All branches with this naming schema will be deleted after they are merged.
 
-In the commit message you should also reference the corresponding issue, e.g. using `closes https://github.com/eclipse-emfcloud/coffee-editor/issues/16`, thus allowing [auto close of issues](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords).
-Please use the absolute URL of the issue instead of just `#16`, as using the absolute URL will allow to correctly reference issues irrespectively from where you open the pull request.
+In the commit message you should also reference the corresponding issue, e.g. using `closes #115` / `closes https://github.com/eclipse-emfcloud/coffee-editor/issues/115`, thus allowing [auto close of issues](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords).
 
 Please make sure you read the [guide for a good commit message](https://chris.beams.io/posts/git-commit/).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Coffee Editor IDE
+# Eclipse EMF.cloud Coffee Editor IDE
 
 An **example** of how to build the Theia-based tools including graphical editos, form-based editors, tree-based editors, textual DSLs, model analyisis, debugging and more. The coffee editor is part of the [emf.cloud](https://www.eclipse.org/emfcloud/) project.
 Please visit the [emf.cloud home page](https://www.eclipse.org/emfcloud/#coffeeeditoroverview) for an overview of all features and an [online live demonstration](https://eclipsesource.com/coffee-editor)!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,24 +1,8 @@
-<!--- https://www.eclipse.org/security/ --->
-_ISO 27005 defines vulnerability as:
- "A weakness of an asset or group of assets that can be exploited by one or more threats."_
+# Eclipse EMF.cloud Coffee Editor IDE Vulnerability Reporting Policy
 
-# Security Policy
+If you think or suspect that you have discovered a new security vulnerability in this project, please do not disclose it on GitHub, e.g. in an issue, a PR, or a discussion. Any such disclosure will be removed/deleted on sight, to promote orderly disclosure, as per the [Eclipse Foundation Vulnerability Reporting Policy](https://www.eclipse.org/security/policy.php).
 
-Eclipse EMF.cloud follows the [Eclipse Vulnerability Reporting Policy](https://www.eclipse.org/security/policy.php). Vulnerabilities are tracked by the Eclipse security team, in cooperation with the EMF.cloud project leads. Fixing vulnerabilities is taken care of by the EMF.cloud project committers, with assistance and guidance of the security team.
+## Reporting a Vulnerability
 
-## Reporting a Security Vulnerability
-
-We recommend that in case of suspected vulnerabilities you do not use the public issue tracker, but instead contact the Eclipse Security Team.
-
-The Eclipse Security Team provides help and advice to Eclipse projects on vulnerability issues and is the first point of contact for handling security vulnerabilities.
-Members of the Security Team are committers on Eclipse Projects and members of the Eclipse Architecture Council. You can contact the Eclipse Security Team via [security@eclipse.org](mailto:security@eclipse.org). Note that, as a matter of policy, the security team does not open attachments.
-
-Members of the Eclipse Security Team will receive messages sent to this address.
-This address should be used only for reporting undisclosed vulnerabilities; regular issue reports and questions unrelated to vulnerabilities in Eclipse software will be ignored.
-Note that this email address is not encrypted.
-
-## Disclosure
-
-Disclosure is initially limited to the reporter and all Eclipse Committers, but is expanded to include other individuals, and the general public.
-The timing and manner of disclosure is governed by the [Eclipse Security Policy](https://www.eclipse.org/security/policy.php).
-Publicly disclosed issues are listed on the [Disclosed Vulnerabilities Page](https://www.eclipse.org/security/known.php).
+We recommend that in case of suspected vulnerabilities you do not use the EMF.cloud Coffee Editor IDE public issue tracker, but instead contact the Eclipse Security Team directly via security@eclipse.org.
+Make sure to provide a concise description of the issue, a CWE, and other supporting information.


### PR DESCRIPTION
- Update community health files to align with emfcloud umbrella repository
- Add EMF.cloud project name to README header 

Part of https://github.com/eclipse-emfcloud/emfcloud/issues/193