### PR TITLE
Update to new modelserver-theia version

### DIFF
--- a/backend/plugins/org.eclipse.emfcloud.coffee.workflow.glsp.server/META-INF/MANIFEST.MF
+++ b/backend/plugins/org.eclipse.emfcloud.coffee.workflow.glsp.server/META-INF/MANIFEST.MF
@@ -24,7 +24,7 @@ Require-Bundle: org.apache.logging.log4j;bundle-version="[2.17.1,3.0.0)",
  org.eclipse.emfcloud.coffee.model;bundle-version="[0.8.0,0.9.0)",
  org.eclipse.emfcloud.coffee.modelserver;bundle-version="[0.8.0,0.9.0)",
  org.eclipse.emfcloud.validation.framework;bundle-version="[0.2.0,0.3.0)",
- org.eclipse.emfcloud.modelserver.emf;bundle-version="0.8.0",
+ org.eclipse.emfcloud.modelserver.emf;bundle-version="0.7.0",
  org.eclipse.lsp4j.jsonrpc;bundle-version="0.12.0"
 Export-Package: org.eclipse.emfcloud.coffee.workflow.glsp.server
 Import-Package: com.google.gson;version="2.8.9",

--- a/backend/releng/org.eclipse.emfcloud.coffee.target/org.eclipse.emfcloud.coffee.target.target
+++ b/backend/releng/org.eclipse.emfcloud.coffee.target/org.eclipse.emfcloud.coffee.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Coffee Editor Targetplatform" sequenceNumber="1676637093">
+<target name="Coffee Editor Targetplatform" sequenceNumber="1681375463">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="ch.qos.logback.slf4j" version="1.2.3.v20221112-0806"/>
@@ -54,11 +54,11 @@
       <repository location="https://download.eclipse.org/emfcloud/emfjson-jackson/p2/releases/2.0.0/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.glsp.graph" version="1.1.0.202302071309"/>
-      <unit id="org.eclipse.glsp.layout" version="1.1.0.202302071309"/>
-      <unit id="org.eclipse.glsp.server" version="1.1.0.202302071309"/>
-      <unit id="org.eclipse.glsp.server.emf" version="1.1.0.202302071309"/>
-      <repository location="https://download.eclipse.org/glsp/server/p2/nightly/1.1/1.1.0.202302071309"/>
+      <unit id="org.eclipse.glsp.graph" version="1.1.0.202303241144"/>
+      <unit id="org.eclipse.glsp.layout" version="1.1.0.202303241144"/>
+      <unit id="org.eclipse.glsp.server" version="1.1.0.202303241144"/>
+      <unit id="org.eclipse.glsp.server.emf" version="1.1.0.202303241144"/>
+      <repository location="https://download.eclipse.org/glsp/server/p2/nightly/1.1/1.1.0.202303241144/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.elk.alg.layered" version="0.8.1"/>
@@ -77,9 +77,9 @@
       <repository location="https://download.eclipse.org/emfcloud/model-validation/p2/nightly/0.2/0.2.0.202203171240/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emfcloud.modelserver.glsp.integration" version="0.8.0.I20230217"/>
-      <unit id="org.eclipse.emfcloud.modelserver.glsp.notation.commands" version="0.8.0.I20230217"/>
-      <repository location="https://download.eclipse.org/emfcloud/modelserver-glsp-integration/p2/integration/0.8.0.I20230217/"/>
+      <unit id="org.eclipse.emfcloud.modelserver.glsp.integration" version="0.7.0.202304120811"/>
+      <unit id="org.eclipse.emfcloud.modelserver.glsp.notation.commands" version="0.7.0.202304120811"/>
+      <repository location="https://download.eclipse.org/emfcloud/modelserver-glsp-integration/p2/nightly/0.7/0.7.0.202304120811/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="2.14.0.v20221117-1134"/>

--- a/backend/releng/org.eclipse.emfcloud.coffee.target/org.eclipse.emfcloud.coffee.target.tpd
+++ b/backend/releng/org.eclipse.emfcloud.coffee.target/org.eclipse.emfcloud.coffee.target.tpd
@@ -60,7 +60,7 @@ location "https://download.eclipse.org/emfcloud/emfjson-jackson/p2/releases/2.0.
 	org.eclipse.emfcloud.emfjson-jackson [2.0.0,2.1.0)
 }
 
-location "https://download.eclipse.org/glsp/server/p2/nightly/1.1/1.1.0.202302071309" {
+location "https://download.eclipse.org/glsp/server/p2/nightly/1.1/1.1.0.202303241144/" {
 	org.eclipse.glsp.graph [1.1.0,2.0.0)
 	org.eclipse.glsp.layout [1.1.0,2.0.0)
 	org.eclipse.glsp.server [1.1.0,2.0.0)
@@ -81,9 +81,9 @@ location "https://download.eclipse.org/emfcloud/model-validation/p2/nightly/0.2/
 	org.eclipse.emfcloud.validation.framework [0.2.0,0.3.0)
 }
 
-location "https://download.eclipse.org/emfcloud/modelserver-glsp-integration/p2/integration/0.8.0.I20230217/" {
-	org.eclipse.emfcloud.modelserver.glsp.integration [0.8.0,0.9.0)
-	org.eclipse.emfcloud.modelserver.glsp.notation.commands [0.8.0,0.9.0)
+location "https://download.eclipse.org/emfcloud/modelserver-glsp-integration/p2/nightly/0.7/0.7.0.202304120811/" {
+	org.eclipse.emfcloud.modelserver.glsp.integration [0.7.0,0.9.0)
+	org.eclipse.emfcloud.modelserver.glsp.notation.commands [0.7.0,0.9.0)
 }
 location "https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.14.0/" {
 	org.eclipse.emf.mwe2.launcher.feature.group [2.12.2,3.0.0)

--- a/client/browser-app/package.json
+++ b/client/browser-app/package.json
@@ -80,7 +80,8 @@
         "preferences": {
           "security.workspace.trust.startupPrompt": "never",
           "security.workspace.trust.enabled": false,
-          "files.autoSave": "off"
+          "files.autoSave": "off",
+          "workbench.colorTheme": "dark"
         }
       }
     }

--- a/client/coffee-editor-extension/package.json
+++ b/client/coffee-editor-extension/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "@eclipse-emfcloud/modelserver-client": "0.8.0-theia-cr02",
-    "@eclipse-emfcloud/modelserver-theia": "0.8.0-theia-cr02",
+    "@eclipse-emfcloud/modelserver-theia": "0.8.0-next.46ba3ca.93",
     "@eclipse-emfcloud/theia-tree-editor": "0.7.0-next.720ee4f"
   },
   "devDependencies": {

--- a/client/coffee-servers/package.json
+++ b/client/coffee-servers/package.json
@@ -25,7 +25,7 @@
     "servers"
   ],
   "dependencies": {
-    "@eclipse-emfcloud/modelserver-theia": "0.8.0-theia-cr02",
+    "@eclipse-emfcloud/modelserver-theia": "0.8.0-next.46ba3ca.93",
     "coffee-cpp-extension": "^0.8.0",
     "coffee-java-extension": "^0.8.0",
     "coffee-workflow-analyzer": "^0.8.0",

--- a/client/coffee-workflow-glsp-theia/package.json
+++ b/client/coffee-workflow-glsp-theia/package.json
@@ -24,7 +24,7 @@
     "src"
   ],
   "dependencies": {
-    "@eclipse-emfcloud/modelserver-theia": "0.8.0-theia-cr02",
+    "@eclipse-emfcloud/modelserver-theia": "0.8.0-next.46ba3ca.93",
     "@eclipse-glsp/theia-integration": "1.1.0-RC05",
     "balloon-css": "^0.5.0",
     "coffee-workflow-glsp": "^0.8.0",


### PR DESCRIPTION
This will fix a problem, where the modelserver was not ready when opening a GLSP editor, which resulted in a GLSP server crash.

To try out in the cloud: https://try.theia-cloud.io/?appDef=coffee-editor.

Expected behaviour: There should be no more issues with Modelserver requests failing, when the application is loaded.

Fixes #494.