### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update &&\
     apt-get -y install --no-install-recommends \
     software-properties-common \
     libxkbfile-dev \
-    libsecret-1-dev openjdk-17-jdk \
+    libsecret-1-dev ca-certificates-java openjdk-17-jdk \
     build-essential libssl-dev wget gnupg git gdb
 
 # C/C++ dependencies


### PR DESCRIPTION
Due to OpenJDK changes (which were also backported to openjdk-17) now the ca-certificates-java package needs to be installed as well.

See also https://bugs.launchpad.net/ubuntu/+source/ca-certificates-java/+bug/2019908, https://launchpad.net/ubuntu/+source/ca-certificates-java/20230103ubuntu1