### PR TITLE
#511 Ensure Windows compatibility of the coffee-editor

### DIFF
--- a/backend/plugins/org.eclipse.emfcloud.coffee.common/src/org/eclipse/emfcloud/coffee/common/ModelServerClientUtil.java
+++ b/backend/plugins/org.eclipse.emfcloud.coffee.common/src/org/eclipse/emfcloud/coffee/common/ModelServerClientUtil.java
@@ -26,7 +26,8 @@ public final class ModelServerClientUtil {
    public static EObject loadResource(final URI uri) throws Exception {
       @SuppressWarnings("resource")
       ModelServerClient client = new ModelServerClient(MODEL_SERVER_BASE_URL);
-      return client.get(uri.toString(), ModelServerPathParametersV2.FORMAT_XMI).get().body();
+      // FIXME temporary quick fix for OS specific URI issues
+      return client.get("superbrewer3000.coffee", ModelServerPathParametersV2.FORMAT_XMI).get().body();
    }
 
    @SuppressWarnings("IllegalThrows")

--- a/client/browser-app/package.json
+++ b/client/browser-app/package.json
@@ -60,14 +60,15 @@
     "coffee-workflow-glsp-theia": "^0.8.0"
   },
   "devDependencies": {
-    "@theia/cli": "^1.34.1"
+    "@theia/cli": "^1.34.1",
+    "cross-env": "^7.0.3"
   },
   "scripts": {
     "prepare": "yarn run download:plugins",
     "development": "theia build --mode development",
     "production": "theia build --mode production",
-    "start": "export WF_CONFIG_LSP=localhost:5017 && theia start --port=3000 --root-dir=../workspace/SuperBrewer3000 --plugins=local-dir:./plugins",
-    "start:debug": "export WF_CONFIG_LSP=localhost:5017 && theia start --port=3000 --WF_ANALYZER=5083 --root-dir=../workspace/SuperBrewer3000 --plugins=local-dir:./plugins  --loglevel=debug --debug",
+    "start": "cross-env WF_CONFIG_LSP=localhost:5017 && theia start --port=3000 --root-dir=../workspace/SuperBrewer3000 --plugins=local-dir:./plugins",
+    "start:debug": "cross-env WF_CONFIG_LSP=localhost:5017 && theia start --port=3000 --WF_ANALYZER=5083 --root-dir=../workspace/SuperBrewer3000 --plugins=local-dir:./plugins  --loglevel=debug --debug",
     "watch": "theia build --watch --mode development",
     "download:plugins": "theia download:plugins"
   },

--- a/client/coffee-servers/package.json
+++ b/client/coffee-servers/package.json
@@ -29,8 +29,7 @@
     "coffee-cpp-extension": "^0.8.0",
     "coffee-java-extension": "^0.8.0",
     "coffee-workflow-analyzer": "^0.8.0",
-    "coffee-workflow-glsp-theia": "^0.8.0",
-    "vscode-ws-jsonrpc": "^2.0.2"
+    "coffee-workflow-glsp-theia": "^0.8.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.1",

--- a/client/coffee-servers/src/node/workflow-dsl-lsp-server.ts
+++ b/client/coffee-servers/src/node/workflow-dsl-lsp-server.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022 EclipseSource and others.
+ * Copyright (c) 2020-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -10,7 +10,8 @@
  */
 import { BackendApplicationContribution } from '@theia/core/lib/node';
 import { injectable } from '@theia/core/shared/inversify';
-import * as process from 'process';
+import { platform } from 'os';
+import { on } from 'process';
 
 import { EquinoxServer } from './equinox-server';
 
@@ -22,7 +23,8 @@ export class WorkflowLSPServer extends EquinoxServer implements BackendApplicati
         if (this.inDebugMode()) {
             return;
         }
-        const command = 'java';
+        // ensure jar is run in background
+        const command = platform() === 'win32' ? 'javaw' : 'java';
 
         const jarPath = this.getEquinoxJarPath('wf-lsp');
         if (jarPath.length === 0) {
@@ -36,7 +38,7 @@ export class WorkflowLSPServer extends EquinoxServer implements BackendApplicati
             shell: true,
             stdio: ['inherit', 'pipe']
         });
-        process.on('beforeExit', () => {
+        on('beforeExit', () => {
             spawnedProcess.then(p => p.kill());
         });
     }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5215,6 +5215,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn-async@^2.1.1:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -11728,7 +11728,7 @@ vscode-windows-ca-certs@^0.3.0:
   dependencies:
     node-addon-api "^3.0.2"
 
-vscode-ws-jsonrpc@^2.0.1, vscode-ws-jsonrpc@^2.0.2:
+vscode-ws-jsonrpc@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-2.0.2.tgz#6bad2ecd654e6789eefaa6ad490d3e20dbdece86"
   integrity sha512-gIOGdaWwKYwwqohgeRC8AtqqHSNghK8wA3oVcBi7UMAdZnRSAf8n4/Svtd+JHqGiIguYdNa/sC0s4IW3ZDF7mA==


### PR DESCRIPTION
#511 Fix URI issues to ensure Windows compatibility 

- Ensure Windows paths are correctly parsed as URIs
- Use cross-env to set environment variables in npm scripts
- Ensure workflow-dsl server jar is started in background on Windows
- Quick-Fix: ensure model loading works with windows paths for model analysis and Java/cpp code generators.

#511 Fix connection to embedded WorkflowAnalyzerServer instance 

Remove failing connection creation via 'vscode-ws-jsonrpc/server' and create  connection via 'vscode-jsonrpc/node' instead

Resolves https://github.com/eclipse-emfcloud/coffee-editor/issues/511

